### PR TITLE
make nginx-reload を追加

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -19,3 +19,7 @@ webserv-it:
 .PHONY: nginx-it
 nginx-it:
 	docker exec -it nginx bash
+
+.PHONY: nginx-reload
+nginx-reload:
+	docker exec -t nginx nginx -s reload


### PR DESCRIPTION
make nginx-reload で nginx の設定ファイルの再読み込みができる｡

`nginx -s reload`

参考資料


[Controlling NGINX Processes at Runtime](https://docs.nginx.com/nginx/admin-guide/basic-functionality/runtime-control/)
[Inside NGINX: How We Designed for Performance & Scale](https://www.nginx.com/blog/inside-nginx-how-we-designed-for-performance-scale/)
