### PR TITLE
複数のリクエストに対するパースを実装

### DIFF
--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -80,7 +80,7 @@ HttpRequest::ParsingPhase HttpRequest::ParseRequestLine(
       return kError;
     }
   } else {
-    SaveBuffer(buffer);
+    SaveCurrentBuffer(buffer);
   }
   return kRequestLine;
 }
@@ -253,7 +253,7 @@ HttpStatus HttpRequest::DecideBodySize() {
   return OK;
 }
 
-void HttpRequest::SaveBuffer(utils::ByteVector &buffer) {
+void HttpRequest::SaveCurrentBuffer(utils::ByteVector &buffer) {
   current_buffer_.insert(current_buffer_.begin(), buffer.begin(), buffer.end());
   buffer.clear();
 }

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -53,6 +53,7 @@ const std::string &HttpRequest::GetPath() const {
 
 void HttpRequest::ParseRequest(utils::ByteVector &buffer) {
   LoadCurrentBuffer(buffer);
+  // TODO 長すぎるbufferは捨ててエラーにする
   if (phase_ == kRequestLine)
     phase_ = ParseRequestLine(buffer);
   if (phase_ == kHeaderField)

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -17,8 +17,7 @@ HttpRequest::HttpRequest()
       phase_(kRequestLine),
       parse_status_(OK),
       body_(),
-      body_size_(0),
-      current_buffer_() {}
+      body_size_(0) {}
 
 HttpRequest::HttpRequest(const HttpRequest &rhs) {
   *this = rhs;
@@ -34,7 +33,6 @@ HttpRequest &HttpRequest::operator=(const HttpRequest &rhs) {
     parse_status_ = rhs.parse_status_;
     body_ = rhs.body_;
     body_size_ = rhs.body_size_;
-    current_buffer_ = rhs.current_buffer_;
   }
   return *this;
 }
@@ -253,18 +251,6 @@ HttpStatus HttpRequest::DecideBodySize() {
     return InterpretContentLength((*length_header_it).second);
 
   return OK;
-}
-
-void HttpRequest::SaveCurrentBuffer(utils::ByteVector &buffer) {
-  std::swap(buffer, current_buffer_);
-  buffer.clear();
-}
-
-void HttpRequest::LoadCurrentBuffer(utils::ByteVector &buffer) {
-  if (current_buffer_.size() == 0)
-    return;
-  buffer.insert(buffer.begin(), current_buffer_.begin(), current_buffer_.end());
-  current_buffer_.clear();
 }
 
 namespace {

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -52,7 +52,6 @@ const std::string &HttpRequest::GetPath() const {
 // Parse系関数　内部でInterpret系関数を呼び出す　主にphaseで動作管理
 
 void HttpRequest::ParseRequest(utils::ByteVector &buffer) {
-  LoadCurrentBuffer(buffer);
   // TODO 長すぎるbufferは捨ててエラーにする
   if (phase_ == kRequestLine)
     phase_ = ParseRequestLine(buffer);
@@ -62,8 +61,6 @@ void HttpRequest::ParseRequest(utils::ByteVector &buffer) {
     phase_ = ParseBodySize();
   if (phase_ == kBody)
     phase_ = ParseBody(buffer);
-  if (phase_ != kParsed && phase_ != kError)
-    SaveCurrentBuffer(buffer);
   PrintRequestInfo();
 }
 

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -213,6 +213,9 @@ HttpStatus HttpRequest::InterpretContentLength(
 bool HttpRequest::IsParsed() {
   return phase_ == kParsed;
 }
+bool HttpRequest::IsCorrectStatus() {
+  return parse_status_ == OK;
+}
 
 //========================================================================
 // Helper関数

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -17,8 +17,7 @@ HttpRequest::HttpRequest()
       phase_(kRequestLine),
       parse_status_(OK),
       body_(),
-      body_size_(0),
-      buffer_() {}
+      body_size_(0) {}
 
 HttpRequest::HttpRequest(const HttpRequest &rhs) {
   *this = rhs;
@@ -33,7 +32,6 @@ HttpRequest &HttpRequest::operator=(const HttpRequest &rhs) {
     phase_ = rhs.phase_;
     parse_status_ = rhs.parse_status_;
     body_ = rhs.body_;
-    buffer_ = rhs.buffer_;
     body_size_ = rhs.body_size_;
   }
   return *this;
@@ -100,7 +98,7 @@ HttpRequest::ParsingPhase HttpRequest::ParseHeaderField(
     if (it == buffer.end()) {
       return kHeaderField;  // crlfがbuffer内に存在しない
     } else {
-      std::string line = buffer_.CutSubstrBeforePos(it);  // headerfieldの解釈
+      std::string line = buffer.CutSubstrBeforePos(it);  // headerfieldの解釈
       if (InterpretHeaderField(line) != OK)
         return kError;
     }

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -209,6 +209,12 @@ HttpStatus HttpRequest::InterpretContentLength(
 }
 
 //========================================================================
+// Is系関数　外部から状態取得
+bool HttpRequest::IsParsed() {
+  return phase_ == kParsed;
+}
+
+//========================================================================
 // Helper関数
 
 HttpStatus HttpRequest::DecideBodySize() {

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -51,26 +51,27 @@ const std::string &HttpRequest::GetPath() const {
 //========================================================================
 // Parse系関数　内部でInterpret系関数を呼び出す　主にphaseで動作管理
 
-void HttpRequest::ParseRequest() {
+void HttpRequest::ParseRequest(utils::ByteVector &buffer) {
   if (phase_ == kRequestLine)
-    phase_ = ParseRequestLine();
+    phase_ = ParseRequestLine(buffer);
   if (phase_ == kHeaderField)
-    phase_ = ParseHeaderField();
+    phase_ = ParseHeaderField(buffer);
   if (phase_ == kBodySize)
     phase_ = ParseBodySize();
   if (phase_ == kBody)
-    phase_ = ParseBody();
+    phase_ = ParseBody(buffer);
   PrintRequestInfo();
 }
 
-HttpRequest::ParsingPhase HttpRequest::ParseRequestLine() {
-  while (buffer_.CompareHead(kCrlf)) {
-    buffer_.EraseHead(kCrlf.size());
+HttpRequest::ParsingPhase HttpRequest::ParseRequestLine(
+    utils::ByteVector &buffer) {
+  while (buffer.CompareHead(kCrlf)) {
+    buffer.EraseHead(kCrlf.size());
   }
 
-  utils::ByteVector::iterator it = buffer_.FindString(kCrlf);
-  if (it != buffer_.end()) {
-    std::string line = buffer_.CutSubstrBeforePos(it);
+  utils::ByteVector::iterator it = buffer.FindString(kCrlf);
+  if (it != buffer.end()) {
+    std::string line = buffer.CutSubstrBeforePos(it);
     if (InterpretMethod(line) == OK && InterpretPath(line) == OK &&
         InterpretVersion(line) == OK) {
       return kHeaderField;
@@ -81,21 +82,22 @@ HttpRequest::ParsingPhase HttpRequest::ParseRequestLine() {
   return kRequestLine;
 }
 
-HttpRequest::ParsingPhase HttpRequest::ParseHeaderField() {
+HttpRequest::ParsingPhase HttpRequest::ParseHeaderField(
+    utils::ByteVector &buffer) {
   while (1) {
-    if (buffer_.CompareHead(kHeaderBoundary)) {
-      buffer_.EraseHead(kHeaderBoundary.size());
+    if (buffer.CompareHead(kHeaderBoundary)) {
+      buffer.EraseHead(kHeaderBoundary.size());
       //先頭が\r\n\r\nなので終了処理
       return kBodySize;
     }
 
-    if (buffer_.CompareHead(kCrlf)) {
+    if (buffer.CompareHead(kCrlf)) {
       // HeaderBoundary判定用に残しておいたcrlfを削除
-      buffer_.EraseHead(kCrlf.size());
+      buffer.EraseHead(kCrlf.size());
     }
 
-    utils::ByteVector::iterator it = buffer_.FindString(kCrlf);
-    if (it == buffer_.end()) {
+    utils::ByteVector::iterator it = buffer.FindString(kCrlf);
+    if (it == buffer.end()) {
       return kHeaderField;  // crlfがbuffer内に存在しない
     } else {
       std::string line = buffer_.CutSubstrBeforePos(it);  // headerfieldの解釈
@@ -111,17 +113,17 @@ HttpRequest::ParsingPhase HttpRequest::ParseBodySize() {
   return kBody;
 }
 
-HttpRequest::ParsingPhase HttpRequest::ParseBody() {
+HttpRequest::ParsingPhase HttpRequest::ParseBody(utils::ByteVector &buffer) {
   if (body_size_ == 0)
     return kParsed;
 
   size_t request_size = body_size_ - body_.size();
-  if (buffer_.size() <= request_size) {
-    body_.insert(body_.end(), buffer_.begin(), buffer_.end());
-    buffer_.clear();
+  if (buffer.size() <= request_size) {
+    body_.insert(body_.end(), buffer.begin(), buffer.end());
+    buffer.clear();
   } else {
-    body_.insert(body_.end(), buffer_.begin(), buffer_.begin() + request_size);
-    buffer_.erase(buffer_.begin(), buffer_.begin() + request_size);
+    body_.insert(body_.end(), buffer.begin(), buffer.begin() + request_size);
+    buffer.erase(buffer.begin(), buffer.begin() + request_size);
   }
   return body_.size() == body_size_ ? kParsed : kBody;
 }

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -259,7 +259,10 @@ void HttpRequest::SaveCurrentBuffer(utils::ByteVector &buffer) {
 }
 
 void HttpRequest::LoadCurrentBuffer(utils::ByteVector &buffer) {
+  if (current_buffer_.size() == 0)
+    return;
   buffer.insert(buffer.begin(), current_buffer_.begin(), current_buffer_.end());
+  current_buffer_.clear();
 }
 
 namespace {

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -259,7 +259,7 @@ HttpStatus HttpRequest::DecideBodySize() {
 }
 
 void HttpRequest::SaveCurrentBuffer(utils::ByteVector &buffer) {
-  current_buffer_.insert(current_buffer_.begin(), buffer.begin(), buffer.end());
+  std::swap(buffer, current_buffer_);
   buffer.clear();
 }
 

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -88,6 +88,10 @@ HttpRequest::ParsingPhase HttpRequest::ParseRequestLine(
 
 HttpRequest::ParsingPhase HttpRequest::ParseHeaderField(
     utils::ByteVector &buffer) {
+  if (buffer.FindString(kHeaderBoundary) == buffer.end()) {
+    return kHeaderField;
+  }
+
   while (1) {
     if (buffer.CompareHead(kHeaderBoundary)) {
       buffer.EraseHead(kHeaderBoundary.size());

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -45,7 +45,6 @@ class HttpRequest {
 
   // buffer内の文字列で処理を完了できない時、current_bufferに文字列を保持して処理を中断
   // 次のbufferが来るのを待つ
-  utils::ByteVector current_buffer_;
 
   // ソケットからはデータを細切れでしか受け取れないので一旦バッファに保管し､行ごとに処理する｡
 
@@ -63,8 +62,6 @@ class HttpRequest {
   bool IsParsed();
 
  private:
-  void SaveCurrentBuffer(utils::ByteVector &buffer);
-  void LoadCurrentBuffer(utils::ByteVector &buffer);
   ParsingPhase ParseRequestLine(utils::ByteVector &buffer);
   ParsingPhase ParseHeaderField(utils::ByteVector &buffer);
   ParsingPhase ParseBodySize();

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -53,16 +53,16 @@ class HttpRequest {
 
   const std::string &GetPath() const;
 
-  void ParseRequest();
+  void ParseRequest(utils::ByteVector &buffer);
   bool IsCorrectRequest();
 
   utils::ByteVector buffer_;  // bufferはSocketInfoに移動予定
 
  private:
-  ParsingPhase ParseRequestLine();
-  ParsingPhase ParseHeaderField();
+  ParsingPhase ParseRequestLine(utils::ByteVector &buffer);
+  ParsingPhase ParseHeaderField(utils::ByteVector &buffer);
   ParsingPhase ParseBodySize();
-  ParsingPhase ParseBody();
+  ParsingPhase ParseBody(utils::ByteVector &buffer);
   HttpStatus InterpretMethod(std::string &str);
   HttpStatus InterpretPath(std::string &str);
   HttpStatus InterpretVersion(std::string &str);

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -42,7 +42,10 @@ class HttpRequest {
   HttpStatus parse_status_;
   utils::ByteVector body_;  // HTTP リクエストのボディ
   unsigned long body_size_;
-  utils::ByteVector current_buffer_;  // HTTP リクエストのボディ
+
+  // buffer内の文字列で処理を完了できない時、current_bufferに文字列を保持して処理を中断
+  // 次のbufferが来るのを待つ
+  utils::ByteVector current_buffer_;
 
   // ソケットからはデータを細切れでしか受け取れないので一旦バッファに保管し､行ごとに処理する｡
 

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -55,6 +55,7 @@ class HttpRequest {
 
   void ParseRequest(utils::ByteVector &buffer);
   bool IsCorrectRequest();
+  bool IsParsed();
 
  private:
   ParsingPhase ParseRequestLine(utils::ByteVector &buffer);

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -55,6 +55,7 @@ class HttpRequest {
 
   void ParseRequest(utils::ByteVector &buffer);
   bool IsCorrectRequest();
+  bool IsCorrectStatus();
   bool IsParsed();
 
  private:

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -56,8 +56,6 @@ class HttpRequest {
   void ParseRequest(utils::ByteVector &buffer);
   bool IsCorrectRequest();
 
-  utils::ByteVector buffer_;  // bufferはSocketInfoに移動予定
-
  private:
   ParsingPhase ParseRequestLine(utils::ByteVector &buffer);
   ParsingPhase ParseHeaderField(utils::ByteVector &buffer);

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -60,7 +60,7 @@ class HttpRequest {
   bool IsParsed();
 
  private:
-  void SaveBuffer(utils::ByteVector &buffer);
+  void SaveCurrentBuffer(utils::ByteVector &buffer);
   void LoadCurrentBuffer(utils::ByteVector &buffer);
   ParsingPhase ParseRequestLine(utils::ByteVector &buffer);
   ParsingPhase ParseHeaderField(utils::ByteVector &buffer);

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -42,6 +42,7 @@ class HttpRequest {
   HttpStatus parse_status_;
   utils::ByteVector body_;  // HTTP リクエストのボディ
   unsigned long body_size_;
+  utils::ByteVector current_buffer_;  // HTTP リクエストのボディ
 
   // ソケットからはデータを細切れでしか受け取れないので一旦バッファに保管し､行ごとに処理する｡
 
@@ -59,6 +60,8 @@ class HttpRequest {
   bool IsParsed();
 
  private:
+  void SaveBuffer(utils::ByteVector &buffer);
+  void LoadCurrentBuffer(utils::ByteVector &buffer);
   ParsingPhase ParseRequestLine(utils::ByteVector &buffer);
   ParsingPhase ParseHeaderField(utils::ByteVector &buffer);
   ParsingPhase ParseBodySize();

--- a/srcs/server/event_loop.cpp
+++ b/srcs/server/event_loop.cpp
@@ -52,13 +52,16 @@ void ProcessRequest(int conn_fd, int epfd, SocketInfo *info) {
   } else {
     info->buffer_.AppendDataToBuffer(buf, n);
 
-    while (info->buffer_.size() != 0) {
+    while (1) {
       if (info->requests.empty() || info->requests.back().IsParsed()) {
         info->requests.push_back(http::HttpRequest());
       }
       info->requests.back().ParseRequest(info->buffer_);
       if (info->requests.back().IsCorrectStatus() == false) {
         info->buffer_.clear();
+      }
+      if (info->buffer_.empty()) {
+        break;
       }
     }
   }

--- a/srcs/server/event_loop.cpp
+++ b/srcs/server/event_loop.cpp
@@ -41,6 +41,10 @@ void AcceptNewConnection(int epfd, int listen_fd) {
   LogConnectionInfoToStdout(client_addr);
 }
 
+void ProcessRequest(SocketInfo *socket_info) {
+  socket_info->request.ParseRequest(socket_info->buffer_);
+}
+
 }  // namespace
 
 int StartEventLoop(const std::vector<int> &listen_fds,
@@ -88,7 +92,7 @@ int StartEventLoop(const std::vector<int> &listen_fds,
           epoll_ctl(epfd, EPOLL_CTL_DEL, conn_fd, NULL);  // 明示的に消してる
         } else {
           socket_info->buffer_.AppendDataToBuffer(buf, n);
-          socket_info->request.ParseRequest(socket_info->buffer_);
+          ProcessRequest(socket_info);
         }
       }
 

--- a/srcs/server/event_loop.cpp
+++ b/srcs/server/event_loop.cpp
@@ -60,7 +60,7 @@ void ProcessRequest(int conn_fd, int epfd, SocketInfo *info) {
       if (info->requests.back().IsCorrectStatus() == false) {
         info->buffer_.clear();
       }
-      if (info->buffer_.empty()) {
+      if (info->buffer_.empty() || info->requests.back().IsParsed() == false) {
         break;
       }
     }

--- a/srcs/server/event_loop.cpp
+++ b/srcs/server/event_loop.cpp
@@ -89,7 +89,7 @@ int StartEventLoop(const std::vector<int> &listen_fds,
         } else {
           //   socket_info->request.buffer_.AppendDataToBuffer();
           socket_info->request.buffer_.AppendDataToBuffer(buf, n);
-          socket_info->request.ParseRequest();
+          socket_info->request.ParseRequest(socket_info->request.buffer_);
           // printf("----- Received data -----\n%s", buf);
         }
       }

--- a/srcs/server/event_loop.cpp
+++ b/srcs/server/event_loop.cpp
@@ -52,10 +52,16 @@ void ProcessRequest(int conn_fd, int epfd, SocketInfo *socket_info) {
   } else {
     socket_info->buffer_.AppendDataToBuffer(buf, n);
 
-    if (socket_info->requests.empty()) {
-      socket_info->requests.push_back(http::HttpRequest());
+    while (socket_info->buffer_.size() != 0) {
+      if (socket_info->requests.empty() ||
+          socket_info->requests.back().IsParsed()) {
+        socket_info->requests.push_back(http::HttpRequest());
+      }
+      socket_info->requests.back().ParseRequest(socket_info->buffer_);
+      if (socket_info->requests.back().IsCorrectStatus() == false) {
+        socket_info->buffer_.clear();
+      }
     }
-    socket_info->requests.back().ParseRequest(socket_info->buffer_);
   }
 }
 

--- a/srcs/server/event_loop.cpp
+++ b/srcs/server/event_loop.cpp
@@ -87,10 +87,8 @@ int StartEventLoop(const std::vector<int> &listen_fds,
           close(conn_fd);
           epoll_ctl(epfd, EPOLL_CTL_DEL, conn_fd, NULL);  // 明示的に消してる
         } else {
-          //   socket_info->request.buffer_.AppendDataToBuffer();
-          socket_info->request.buffer_.AppendDataToBuffer(buf, n);
-          socket_info->request.ParseRequest(socket_info->request.buffer_);
-          // printf("----- Received data -----\n%s", buf);
+          socket_info->buffer_.AppendDataToBuffer(buf, n);
+          socket_info->request.ParseRequest(socket_info->buffer_);
         }
       }
 

--- a/srcs/server/event_loop.hpp
+++ b/srcs/server/event_loop.hpp
@@ -29,7 +29,7 @@ struct SocketInfo {
   ESockType socktype;
   EPhase phase;  // リクエストが読み込み終わってないときは Request,
                  // 読み込み終わったら Response
-  http::HttpRequest request;
+  std::vector<http::HttpRequest> requests;
   http::HttpResponse response;
   utils::ByteVector buffer_;
 };


### PR DESCRIPTION
### やったこと

- 複数リクエストが同一FDに連続できたときにパースできるようになった
- readに使うbufferの大きさを極端に小さくしても複数リクエストのパースができるようになった

-----

### メモ
- epollループのINイベントを関数に分割(ProcessRequest関数)
- requestが持ってたbufferをsocket_infoに移動。
- socket_infoがrequestをvectorで持つよう変更
- parserをbufferがなくなるまでwhileで実行するよう変更
- ↑途中でエラーが出たらbufferをクリアする
- request内にByteVectorのcurrent_buffer_を追加
- ~↑parse途中で正常系だけどbufferに文字列が残ってしまうパターンがあるため。参考: https://github.com/JUNNETWORKS/42-webserv/commit/9d9744247353b71eb0ee70f17088b1aa90c3a0ce~
- 出力側はエラー起きないようにしただけでノータッチ
- ~Parse時にcurrent_bufferをbufferの先頭に追加してからParseする~
- ~↑bufferとcurrent_bufferの境目にCRLFがあるときに検索から漏れてしまう可能性があるのでその対策~
- ~bufferとcurrent_bufferを結合してから処理をする関係上、同じ文字列に同じ検索処理が複数回走る(FindString)~
- bufferの最大サイズでbufferを破棄する処理を入れる予定なのでめちゃくちゃ大きな計算量になることはない...はず
- ヘッダーとボディの境目がbufferに見つかってからParseだと↑の問題が解消されるので要検討（ヘッダーを受信しきるまでParseが始まらないようにする）

~bufferに解釈途中の文字列を残すと、Parseのwhileの条件文がつけられなくなる。~
~パース完了、パース途中、エラー発生のパターンをbufからは読み取れない。~
~ParseRequest内でParse途中,失敗,たまたま切りのいいところでbufがなくなったみたいなパターンたちを返り値で判断することが難しい~
~→Parse途中の時はbufferをcurrent_bufに保存しておいて再度処理のタイミングでLoadするようにした~

current_buffer_がいらなくなったのですべてが過去になった

---------------

### テスト例
```
POST / HTTP/1.1
Host: localhost:49200
User-Agent: Hitokage
Content-length: 10
Accept: */*

0123456789POST / HTTP/1.1
Host: localhost:49200
User-Agent: Pikachu
Content-length: 10
Accept: */*

aiueoaiueo
```

```
POST / HTTP/1.1
Host: localhost:49200
User-Agent: Hitokage
Content-length: 10
Accept: */*

0123456789


POST / HTTP/1.1
Host: localhost:49200
User-Agent: Pikachu
Content-length: 10
Accept: */*

aiueoaiueo
```



```
GET / HTTP/1.1
Host: localhost:49200

GET / HTTP/1.1
Host: localhost:49200


```