### PR TITLE
Strtoul() の修正とConfigParserのIPアドレス対応

### DIFF
--- a/docs/configuration.g4
+++ b/docs/configuration.g4
@@ -10,7 +10,7 @@ server_directive:
 
 listen_directive: 'listen' WHITESPACE NUMBER END_DIRECTIVE;
 servername_directive:
-	'server_name' WHITESPACE DOMAIN_NAME+ END_DIRECTIVE;
+	'server_name' WHITESPACE ((DOMAIN_NAME | IP_ADDR) WHITESPACE)+ END_DIRECTIVE;
 location_directive:
 	'location' PATH '{' directive_in_location+ '}';
 location_back_directive:
@@ -41,6 +41,7 @@ METHOD: 'GET' | 'POST' | 'DELETE';
 PATH: (.*? '/')? (.+?);
 URL: ('http' | 'https') '://' DOMAIN_NAME ('/');
 DOMAIN_NAME: DOMAIN_LABEL ('.' DOMAIN_LABEL)*;
+IP_ADDR: NUMBER+ '.' NUMBER+ '.' NUMBER+ '.' NUMBER+;
 DOMAIN_LABEL: (ALPHABET | NUMBER)+
 	| (ALPHABET | NUMBER)+ (ALPHABET | NUMBER | HYPHEN)* (
 		ALPHABET

--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -388,19 +388,9 @@ bool Parser::IsValidHttpStatusCode(const std::string &code) {
   return false;
 }
 
-bool Parser::IsValidPort(const std::string port) {
-  if (!utils::IsDigits(port)) {
-    return false;
-  }
-
-  int num;
-  try {
-    num = utils::Stoi(port);
-  } catch (...) {
-    return false;
-  }
-
-  return num >= kMinPortNumber && num <= kMaxPortNumber;
+bool Parser::IsValidPort(const std::string &port) {
+  unsigned long num;
+  return utils::Stoul(num, port) && num <= kMaxPortNumber;
 }
 
 bool Parser::ParseOnOff(const std::string &on_or_off) {

--- a/srcs/config/config_parser.hpp
+++ b/srcs/config/config_parser.hpp
@@ -113,7 +113,7 @@ class Parser {
   bool IsValidHttpStatusCode(const std::string &code);
 
   // portが符号なし整数であり､ポート番号の範囲に収まっているかチェックする
-  bool IsValidPort(const std::string port);
+  bool IsValidPort(const std::string &port);
 
   // "on" なら true, "off" なら false を返す｡
   bool ParseOnOff(const std::string &on_or_off);
@@ -128,10 +128,8 @@ class Parser {
   static const int kMaxDomainLength = 253;
   // ドメインの各ラベル(ピリオド区切りの文字列)の最大長
   static const int kMaxDomainLabelLength = 63;
-  // ポート番号の最小値
-  static const int kMinPortNumber = 0;
   // ポート番号の最大値
-  static const int kMaxPortNumber = 65535;
+  static const unsigned long kMaxPortNumber = 65535;
 };
 
 }  // namespace config

--- a/srcs/utils/string.cpp
+++ b/srcs/utils/string.cpp
@@ -52,6 +52,7 @@ bool Stoul(unsigned long &result, const std::string &str) {
   char *end;
   const char *p = str.c_str();
   int base = 10;
+  errno = 0;
   unsigned long num = std::strtoul(p, &end, base);
   size_t used_char_count = end - p;
 

--- a/unit_test/config/parser_test.cpp
+++ b/unit_test/config/parser_test.cpp
@@ -539,4 +539,22 @@ TEST(ParserTest, HttpStatusInErrorPagesAreInvalid) {
   }
 }
 
+TEST(ParserTest, ValidIpv4AddrInServername) {
+  Parser parser;
+  parser.LoadData(
+      "server {                                     "
+      "  listen 8080;                               "
+      "  server_name localhost 198.0.255.1;         "
+      "                                             "
+      "  location / {                               "
+      "    root /var/www/html;                      "
+      "    index index.html;                        "
+      "  }                                          "
+      "}                                            ");
+  Config config = parser.ParseConfig();
+  EXPECT_TRUE(
+      config.GetVirtualServerConfs()[0].IsServerNameIncluded("198.0.255.1"));
+  EXPECT_TRUE(config.GetVirtualServerConf("8080", "198.0.255.1") != NULL);
+}
+
 }  // namespace config


### PR DESCRIPTION
close #48 

`utils::Strtoul()` の修正｡

`Parser::IsValidPort()` で `utils::Stoul()` を使うようにした.

ConfigParserのIPアドレス対応は基本的にはテストを追加しただけ｡なぜならドメインのルールがIPv4アドレスを内包する形になっているから｡