### PR TITLE
ヘッダーの分割とエスケープを追加

### DIFF
--- a/srcs/http/http_constants.hpp
+++ b/srcs/http/http_constants.hpp
@@ -9,6 +9,7 @@ const std::string kHeaderBoundary = kCrlf + kCrlf;
 const std::string kHttpVersionPrefix = "HTTP/";
 const std::string kExpectMajorVersion = "1.";
 const int kMinorVersionDigitLimit = 3;
+const std::string kOWS = "\t ";
 }  // namespace http
 
 #endif

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -273,7 +273,6 @@ bool CutSubstrHeaderValue(std::string &res, std::string &str) {
   bool is_quoting = false;
   std::string result;
   std::string::iterator it = str.begin();
-  std::string::iterator quote_pos;
   for (; it != str.end(); it++) {
     if (is_quoting) {
       if (*it == '"') {
@@ -286,7 +285,6 @@ bool CutSubstrHeaderValue(std::string &res, std::string &str) {
       }
     } else {
       if (*it == '"') {
-        quote_pos = it;
         is_quoting = true;
       } else if (*it == ',') {
         break;

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -189,7 +189,7 @@ HttpStatus HttpRequest::InterpretHeaderField(std::string &str) {
   std::string header = str.substr(0, collon_pos);
   std::transform(header.begin(), header.end(), header.begin(), toupper);
   str.erase(0, collon_pos + 1);
-  std::string field = utils::TrimString(str, " ");
+  std::string field = utils::TrimString(str, kOWS);
 
   // TODO ,区切りのsplit
   headers_[header].push_back(field);

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -189,7 +189,7 @@ HttpStatus HttpRequest::InterpretHeaderField(std::string &str) {
   std::string header = str.substr(0, collon_pos);
   std::transform(header.begin(), header.end(), header.begin(), toupper);
   str.erase(0, collon_pos + 1);
-  std::string field = utils::TrimWhiteSpace(str);
+  std::string field = utils::TrimString(str, " ");
 
   // TODO ,区切りのsplit
   headers_[header].push_back(field);

--- a/srcs/utils/string.cpp
+++ b/srcs/utils/string.cpp
@@ -90,6 +90,7 @@ std::vector<std::string> SplitString(const std::string &str,
 std::string TrimString(std::string &str, const std::string &charset) {
   size_t start_pos = str.find_first_not_of(charset);
   if (start_pos == std::string::npos) {
+    str.clear();
     return str;
   }
   str.erase(str.begin(), str.begin() + start_pos);

--- a/srcs/utils/string.cpp
+++ b/srcs/utils/string.cpp
@@ -87,9 +87,9 @@ std::vector<std::string> SplitString(const std::string &str,
   return strs;
 }
 
-std::string TrimWhiteSpace(std::string &str) {
-  size_t start_pos = str.find_first_not_of(" ");
-  size_t end_pos = str.find_last_not_of(" ");
+std::string TrimString(std::string &str, const std::string &charset) {
+  size_t start_pos = str.find_first_not_of(charset);
+  size_t end_pos = str.find_last_not_of(charset);
   if (start_pos == std::string::npos)
     str.erase(str.begin(), str.end());
   str.erase(str.begin(), str.begin() + start_pos);

--- a/srcs/utils/string.cpp
+++ b/srcs/utils/string.cpp
@@ -90,10 +90,13 @@ std::vector<std::string> SplitString(const std::string &str,
 std::string TrimString(std::string &str, const std::string &charset) {
   size_t start_pos = str.find_first_not_of(charset);
   size_t end_pos = str.find_last_not_of(charset);
-  if (start_pos == std::string::npos)
-    str.erase(str.begin(), str.end());
+  if (start_pos == std::string::npos) {
+    return str;
+  }
   str.erase(str.begin(), str.begin() + start_pos);
-  str.erase(str.begin() + end_pos, str.end());
+  str.erase(str.begin() + end_pos + 1, str.end());
+  //↑indexとiteratorで数え方にずれがでるため調整の+1
+  // str.begin() + end_posだと一番後ろの文字が一文字分消える
   return str;
 }
 

--- a/srcs/utils/string.cpp
+++ b/srcs/utils/string.cpp
@@ -89,11 +89,12 @@ std::vector<std::string> SplitString(const std::string &str,
 
 std::string TrimString(std::string &str, const std::string &charset) {
   size_t start_pos = str.find_first_not_of(charset);
-  size_t end_pos = str.find_last_not_of(charset);
   if (start_pos == std::string::npos) {
     return str;
   }
   str.erase(str.begin(), str.begin() + start_pos);
+
+  size_t end_pos = str.find_last_not_of(charset);
   str.erase(str.begin() + end_pos + 1, str.end());
   //↑indexとiteratorで数え方にずれがでるため調整の+1
   // str.begin() + end_posだと一番後ろの文字が一文字分消える

--- a/srcs/utils/string.hpp
+++ b/srcs/utils/string.hpp
@@ -38,7 +38,9 @@ bool Stoul(unsigned long &result, const std::string &str);
 std::vector<std::string> SplitString(const std::string &str,
                                      const std::string &delim);
 
-std::string TrimWhiteSpace(std::string &str);
+// str の前後からcharsetに含まれる文字を消して返す
+// e.g. TrimString("abcHELLOabcbca"") return HELLO
+std::string TrimString(std::string &str, const std::string &charset);
 
 bool ReadFile(const std::string &path, std::string &dest);
 

--- a/srcs/utils/string.hpp
+++ b/srcs/utils/string.hpp
@@ -39,7 +39,7 @@ std::vector<std::string> SplitString(const std::string &str,
                                      const std::string &delim);
 
 // str の前後からcharsetに含まれる文字を消して返す
-// e.g. TrimString("abcHELLOabcbca"") return HELLO
+// e.g. TrimString("abcHELLOabcbca", "abc"") return HELLO
 std::string TrimString(std::string &str, const std::string &charset);
 
 bool ReadFile(const std::string &path, std::string &dest);


### PR DESCRIPTION
## スプリットのルール
- DQUOTEで囲まれている文字列の内部でのみエスケープが効く
- エスケープされてないDQUOTEは取り除く
- DQUOTEで囲まれていないカンマまでをreturnする。カンマはstrに残る
- ペアの存在しないDQUOTEは文字扱いでのこる。

## 例
```
Hoge: hello, world
↓
hello
world

Hoge: "hello, world"
↓
hello, world


Hoge: "hello
↓
"hello

If-Match: "strong", W/"weak", "oops, a \"comma\""
↓
strong
W/weak
oops, a "comma"
``` 