### PR TITLE
resultクラスを作る

### DIFF
--- a/srcs/utils/result.cpp
+++ b/srcs/utils/result.cpp
@@ -1,0 +1,31 @@
+#include "utils/result.hpp"
+
+namespace utils {
+
+Error::Error(bool is_err) : is_err_(is_err) {}
+
+Error::Error(const std::string &err_msg) : is_err_(true), err_msg_(err_msg) {}
+
+Error::Error(const Error &other) {
+  *this = other;
+}
+
+const Error &Error::operator=(const Error &rhs) {
+  if (this != &rhs) {
+    is_err_ = rhs.is_err_;
+    err_msg_ = rhs.err_msg_;
+  }
+  return *this;
+}
+
+Error::~Error() {}
+
+bool Error::IsErr() {
+  return is_err_;
+}
+
+const std::string &Error::Print() {
+  return err_msg_;
+}
+
+}  // namespace utils

--- a/srcs/utils/result.hpp
+++ b/srcs/utils/result.hpp
@@ -1,0 +1,112 @@
+#ifndef UTILS_RESULT_HPP_
+#define UTILS_RESULT_HPP_
+
+#include <string>
+
+namespace utils {
+
+// Result でエラーを表すためのクラス
+class Error {
+ private:
+  bool is_err_;
+  std::string err_msg_;
+
+ public:
+  Error(bool is_err = true);
+
+  // エラーメッセージを設定する｡
+  // is_err は true に設定される｡
+  Error(const std::string &err_msg);
+
+  Error(const Error &other);
+
+  const Error &operator=(const Error &rhs);
+
+  ~Error();
+
+  bool IsErr();
+  const std::string &Print();
+};
+
+// エラーが発生するかもしれない関数の返り値として利用する｡
+// T に参照は利用できない｡なぜならエラーの際に表す値が存在しないから｡
+//
+// ===== Usage =====
+// Result<int> succeed() {  // 成功
+//   return Result<int>(10);
+// }
+//
+// Result<void> succeedVoid() {  // 成功 (返り値がvoid)
+//   return Result<void>();
+// }
+//
+// Result<void> fail() {  // エラー
+//   return Result<void>(Error("This is error!"));
+// }
+//
+// int main(){
+//   Result<int> a = succeed();
+//   if (a.IsOk()) {
+//     std::cout << "val: " << a.Ok() << std::endl;
+//   }
+//   if (a.IsErr()) {
+//     std::cout << "err: " << a.Err().Print() << std::endl;
+//   }
+// }
+template <typename T>
+class Result {
+ private:
+  T val_;
+  Error err_;
+
+ public:
+  // デフォルトコンストラクタが存在しない場合にエラーを通知したい場合はこのコンストラクタを使う｡
+  Result(const T &val, const Error &err) : val_(val), err_(err) {}
+
+  Result(const T &val) : val_(val), err_(false) {}
+
+  // デフォルトコンストラクタが存在しない場合は使えない
+  Result(const Error &err) : val_(), err_(err) {}
+
+  bool IsOk() {
+    return !err_.IsErr();
+  }
+  T Ok() {
+    return val_;
+  }
+  bool IsErr() {
+    return err_.IsErr();
+  }
+  Error Err() {
+    return err_;
+  }
+};
+
+// T = void の場合はメンバー変数 val_ を保持することはできない｡
+//   Ok() も利用できない｡ エラーチェックのみ行うことができる｡
+//
+// 返り値が void 型の関数の返り値は利用しないことを考えれば適切な挙動である｡
+template <>
+class Result<void> {
+ private:
+  Error err_;
+
+ public:
+  Result() : err_(false) {}
+
+  Result(const Error &err) : err_(err) {}
+
+  bool IsOk() {
+    return !err_.IsErr();
+  }
+  bool IsErr() {
+    return err_.IsErr();
+  }
+  Error Err() {
+    return err_;
+  }
+};
+
+}  // namespace utils
+
+#endif

--- a/unit_test/utils/result_test.cpp
+++ b/unit_test/utils/result_test.cpp
@@ -1,0 +1,91 @@
+#include "utils/result.hpp"
+
+#include <gtest/gtest.h>
+
+namespace utils {
+namespace {
+
+class NoConstructorClass {
+ private:
+  int n_;
+
+ public:
+  NoConstructorClass(int n) : n_(n) {}
+
+  int GetN() {
+    return n_;
+  }
+
+ private:
+  NoConstructorClass();
+};
+
+Result<int> ReturnInt() {
+  return 10;
+}
+TEST(ResultTest, ReturnInt) {
+  Result<int> result = ReturnInt();
+  EXPECT_TRUE(result.IsOk());
+  EXPECT_EQ(result.Ok(), 10);
+  EXPECT_FALSE(result.IsErr());
+}
+
+Result<int> ReturnIntError() {
+  return Result<int>(10, Error("Error ReturnIntError"));
+}
+TEST(ResultTest, ReturnIntError) {
+  Result<int> result = ReturnIntError();
+  EXPECT_FALSE(result.IsOk());
+  EXPECT_TRUE(result.IsErr());
+  EXPECT_EQ(result.Err().Print(), "Error ReturnIntError");
+}
+
+Result<void> ReturnVoid() {
+  // void の時は明示的にインスタンスを作成してreturnする必要がある.
+  return Result<void>();
+}
+TEST(ResultTest, ReturnVoid) {
+  Result<void> result = ReturnVoid();
+  EXPECT_TRUE(result.IsOk());
+  EXPECT_FALSE(result.IsErr());
+}
+
+Result<void> ReturnVoidError() {
+  return Error("Error ReturnVoidError");
+}
+TEST(ResultTest, ReturnVoidError) {
+  Result<void> result = ReturnVoidError();
+  EXPECT_FALSE(result.IsOk());
+  EXPECT_TRUE(result.IsErr());
+  EXPECT_EQ(result.Err().Print(), "Error ReturnVoidError");
+}
+
+Result<std::vector<int> > ReturnVector() {
+  std::vector<int> vec;
+  for (int i = 0; i < 10; ++i) {
+    vec.push_back(i);
+  }
+  return vec;
+}
+TEST(ResultTest, ReturnVector) {
+  Result<std::vector<int> > result = ReturnVector();
+  EXPECT_TRUE(result.IsOk());
+  EXPECT_FALSE(result.IsErr());
+  const std::vector<int>& vec = result.Ok();
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(vec[i], i);
+  }
+}
+
+Result<NoConstructorClass> ReturnNoConstructorObject() {
+  return NoConstructorClass(10);
+}
+TEST(ResultTest, ReturnNoConstructorObject) {
+  Result<NoConstructorClass> result = ReturnNoConstructorObject();
+  EXPECT_TRUE(result.IsOk());
+  EXPECT_EQ(result.Ok().GetN(), 10);
+  EXPECT_FALSE(result.IsErr());
+}
+
+}  // namespace
+}  // namespace utils


### PR DESCRIPTION
close #62 

ResultクラスとResultクラスでエラーを表すためのErrorクラスを作った｡

参考
- [result.h - Android Code Search](https://cs.android.com/android/platform/superproject/+/master:system/libbase/include/android-base/result.h) : これからアイデアを得た｡
- [epoll.cpp - Android Code Search](https://cs.android.com/android/platform/superproject/+/master:system/core/init/epoll.cpp) : 上記のAndroidのResultクラスの使い方の例｡