### PR TITLE
エラーを返す可能性のある関数でboolでエラーを表すのではなくresult型を使う

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ re: fclean all
 
 ############ GooleTest ############
 
+TEST_DIR    := unit_test
 TESTER_NAME := ./tester
 
 GTEST_DIR   := ./google_test
@@ -52,7 +53,7 @@ TEST_DEPENDENCIES \
 -include $(TEST_DEPENDENCIES)
 
 .PHONY: test
-test: CXXFLAGS := -I$(SRCS_DIR) --std=c++11 -I$(GTEST_DIR) -g3 -fsanitize=address
+test: CXXFLAGS := -I$(SRCS_DIR) -I$(TEST_DIR) --std=c++11 -I$(GTEST_DIR) -g3 -fsanitize=address
 test: $(GTEST) $(TEST_OBJS)
 	# Google Test require C++11
 	$(CXX) $(CXXFLAGS) $(GTEST_MAIN) $(GTEST_ALL) \

--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -175,10 +175,11 @@ void Parser::ParseAllowMethodDirective(LocationConf &location) {
 void Parser::ParseClientMaxBodySizeDirective(LocationConf &location) {
   SkipSpaces();
   std::string body_size_str = GetWord();
-  unsigned long body_size;
-  if (utils::Stoul(body_size, body_size_str) == false) {
+  Result<unsigned long> result = utils::Stoul(body_size_str);
+  if (result.IsErr()) {
     throw ParserException("Invalid body size.");
   }
+  unsigned long body_size = result.Ok();
   location.SetClientMaxBodySize(body_size);
   SkipSpaces();
   if (GetC() != ';') {
@@ -389,8 +390,8 @@ bool Parser::IsValidHttpStatusCode(const std::string &code) {
 }
 
 bool Parser::IsValidPort(const std::string &port) {
-  unsigned long num;
-  return utils::Stoul(num, port) && num <= kMaxPortNumber;
+  Result<unsigned long> result = utils::Stoul(port);
+  return result.IsOk() && result.Ok() <= kMaxPortNumber;
 }
 
 bool Parser::ParseOnOff(const std::string &on_or_off) {

--- a/srcs/config/config_parser.hpp
+++ b/srcs/config/config_parser.hpp
@@ -7,8 +7,11 @@
 #include "config/config.hpp"
 #include "config/location_conf.hpp"
 #include "config/virtual_server_conf.hpp"
+#include "result/result.hpp"
 
 namespace config {
+
+using namespace result;
 
 class Parser {
  public:

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -216,9 +216,11 @@ HttpStatus HttpRequest::InterpretContentLength(
   if (length_header.size() != 1)
     return parse_status_ = BAD_REQUEST;
 
-  if (utils::Stoul(body_size_, length_header.front()) == false)
+  Result<unsigned long> result = utils::Stoul(length_header.front());
+  if (result.IsErr())
     return parse_status_ = BAD_REQUEST;
 
+  body_size_ = result.Ok();
   const unsigned long kMaxSize = 1073741824;  // TODO config読み込みに変更
   if (body_size_ > kMaxSize)
     return parse_status_ = PAYLOAD_TOO_LARGE;

--- a/srcs/result/result.cpp
+++ b/srcs/result/result.cpp
@@ -1,6 +1,6 @@
-#include "utils/result.hpp"
+#include "result/result.hpp"
 
-namespace utils {
+namespace result {
 
 Error::Error(bool is_err) : is_err_(is_err) {}
 
@@ -30,4 +30,4 @@ std::string Error::GetMessage() {
   return err_msg_;
 }
 
-}  // namespace utils
+}  // namespace result

--- a/srcs/result/result.hpp
+++ b/srcs/result/result.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace utils {
+namespace result {
 
 // Result でエラーを表すためのクラス
 class Error {
@@ -111,6 +111,6 @@ class Result<void> {
   }
 };
 
-}  // namespace utils
+}  // namespace result
 
 #endif

--- a/srcs/result/result.hpp
+++ b/srcs/result/result.hpp
@@ -1,6 +1,7 @@
 #ifndef UTILS_RESULT_HPP_
 #define UTILS_RESULT_HPP_
 
+#include <cassert>
 #include <string>
 
 namespace result {
@@ -76,12 +77,14 @@ class Result {
     return !err_.IsErr();
   }
   T Ok() {
+    assert(IsOk());
     return val_;
   }
   bool IsErr() {
     return err_.IsErr();
   }
   Error Err() {
+    assert(IsErr());
     return err_;
   }
 };

--- a/srcs/utils/io.cpp
+++ b/srcs/utils/io.cpp
@@ -25,6 +25,7 @@ bool IsDir(const std::string& file_path) {
   return S_ISDIR(sb.st_mode);
 }
 
+// TODO: ssoがResult返すようにする｡
 bool GetFileList(const std::string& file_path, std::vector<std::string>& vec) {
   struct dirent* dent;
   DIR* dir = opendir(file_path.c_str());

--- a/srcs/utils/string.cpp
+++ b/srcs/utils/string.cpp
@@ -44,9 +44,9 @@ bool IsDigits(const std::string &str) {
   return true;
 }
 
-bool Stoul(unsigned long &result, const std::string &str) {
+Result<unsigned long> Stoul(const std::string &str) {
   if (!IsDigits(str)) {
-    return false;
+    return Error();
   }
 
   char *end;
@@ -62,10 +62,9 @@ bool Stoul(unsigned long &result, const std::string &str) {
   // unsigned long の範囲超えてる
   // すべての文字が数字として認識されなかった
   if (p == end || errno == ERANGE || str.size() != used_char_count) {
-    return false;
+    return Error();
   }
-  result = num;
-  return true;
+  return num;
 }
 
 std::vector<std::string> SplitString(const std::string &str,

--- a/srcs/utils/string.hpp
+++ b/srcs/utils/string.hpp
@@ -6,7 +6,11 @@
 #include <string>
 #include <vector>
 
+#include "result/result.hpp"
+
 namespace utils {
+
+using namespace result;
 
 // 前方一致｡
 // e.g. str="/upload/icon.jpg",  pattern="/upload/" then return true
@@ -31,7 +35,7 @@ bool IsDigits(const std::string &str);
 // 変換がが失敗した場合はfalseを返す
 // 全部数字の文字列以外は失敗する設計｡符号もだめ｡
 // e.g. "42hoge", "hoge42", "+42" -> false   "42" -> true
-bool Stoul(unsigned long &result, const std::string &str);
+Result<unsigned long> Stoul(const std::string &str);
 
 // str を delim で区切った文字列vectorを返す｡
 // e.g. SplitString("a,bc,,d", ",") return ["a", "bc", ,"", "d"]

--- a/unit_test/expectations/expect_result.hpp
+++ b/unit_test/expectations/expect_result.hpp
@@ -1,0 +1,34 @@
+#ifndef UNIT_TEST_EXPECT_RESULT_HPP_
+#define UNIT_TEST_EXPECT_RESULT_HPP_
+
+#include <gtest/gtest.h>
+
+#include "result/result.hpp"
+#include "stdio.h"
+
+using namespace result;
+
+template <typename T>
+void EXPECT_RESULT_IS_OK(Result<T> res1) {
+  EXPECT_TRUE(res1.IsOk());
+}
+
+template <typename T>
+void EXPECT_RESULT_OK_EQ(Result<T> res1, Result<T> res2) {
+  EXPECT_EQ(res1.Ok(), res2.Ok());
+}
+
+template <typename T>
+void EXPECT_RESULT_IS_ERR(Result<T> res1) {
+  EXPECT_TRUE(res1.IsErr());
+}
+
+template <typename T>
+void EXPECT_RESULT_ERR_EQ(Result<T> res1, Result<T> res2) {
+  Error err1 = res1.Err();
+  Error err2 = res2.Err();
+  EXPECT_EQ(err1.IsErr(), err2.IsErr());
+  EXPECT_EQ(err1.GetMessage(), err2.GetMessage());
+}
+
+#endif

--- a/unit_test/result/result_test.cpp
+++ b/unit_test/result/result_test.cpp
@@ -1,9 +1,8 @@
-#include "utils/result.hpp"
+#include "result/result.hpp"
 
 #include <gtest/gtest.h>
 
-namespace utils {
-namespace {
+namespace result {
 
 class NoConstructorClass {
  private:
@@ -100,5 +99,10 @@ TEST(ResultTest, ReturnNoConstructorObjectAndError) {
             "Error ReturnNoConstructorObjectAndError");
 }
 
-}  // namespace
-}  // namespace utils
+TEST(ResultTest, ErrorDefaultConstructor) {
+  Result<void> result = Error();
+  EXPECT_FALSE(result.IsOk());
+  EXPECT_TRUE(result.IsErr());
+}
+
+}  // namespace result

--- a/unit_test/utils/string_test.cpp
+++ b/unit_test/utils/string_test.cpp
@@ -2,68 +2,59 @@
 
 #include <gtest/gtest.h>
 
+#include "expectations/expect_result.hpp"
+
 namespace utils {
 
 TEST(StoulTest, Zero) {
-  unsigned long num;
-  EXPECT_TRUE(Stoul(num, "0"));
-  EXPECT_EQ(num, 0);
+  EXPECT_RESULT_IS_OK(Stoul("0"));
+  EXPECT_RESULT_OK_EQ(Stoul("0"), Result<unsigned long>(0));
 }
 
 TEST(StoulTest, Maximumvalue) {
-  unsigned long num;
-  EXPECT_TRUE(Stoul(num, "18446744073709551615"));
-  EXPECT_EQ(num, 18446744073709551615ul);
+  EXPECT_RESULT_IS_OK(Stoul("18446744073709551615"));
+  EXPECT_RESULT_OK_EQ(Stoul("18446744073709551615"),
+                      Result<unsigned long>(18446744073709551615ul));
 }
 
 TEST(StoulTest, MaximumvalueWithPlusSign) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "+18446744073709551615"));
+  EXPECT_RESULT_IS_ERR(Stoul("+18446744073709551615"));
 }
 
 TEST(StoulTest, MaximumvaluePlusOne) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "18446744073709551616"));
+  EXPECT_RESULT_IS_ERR(Stoul("18446744073709551616"));
 }
 
 TEST(StoulTest, MaximumvalueWithPlusSigns) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "+++++++++++18446744073709551615"));
+  EXPECT_RESULT_IS_ERR(Stoul("+++++++++++18446744073709551615"));
 }
 
 TEST(StoulTest, MinusOne) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "-1"));
+  EXPECT_RESULT_IS_ERR(Stoul("-1"));
 }
 
 TEST(StoulTest, MinusSigns) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "--------1"));
+  EXPECT_RESULT_IS_ERR(Stoul("--------1"));
 }
 
 TEST(StoulTest, PlusZero) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "+0"));
+  EXPECT_RESULT_IS_ERR(Stoul("+0"));
 }
 
 TEST(StoulTest, MinusZero) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "-0"));
+  EXPECT_RESULT_IS_ERR(Stoul("-0"));
 }
 
 TEST(StoulTest, IncludeAlphabetFront) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "a100"));
+  EXPECT_RESULT_IS_ERR(Stoul("a100"));
 }
 
 TEST(StoulTest, IncludeAlphabetBack) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "100a"));
+  EXPECT_RESULT_IS_ERR(Stoul("100a"));
 }
 
 TEST(StoulTest, IncludeAlphabetMiddle) {
-  unsigned long num;
-  EXPECT_FALSE(Stoul(num, "10a0"));
+  EXPECT_RESULT_IS_ERR(Stoul("10a0"));
 }
 
 }  // namespace utils


### PR DESCRIPTION
ConfigParser関連などはまだ変えていない｡変えていない箇所は別PRで変える｡

一旦全体に影響ある部分のみResult型を返すようにした｡