### PR TITLE
接続済みソケットから一定時間データが来なかった場合にタイムアウトとして切断処理を行う

### DIFF
--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -239,8 +239,8 @@ bool HttpRequest::IsCorrectStatus() {
 
 // ========================================================================
 // Getter and Setter
-const std::vector<std::string> &HttpRequest::GetHeader(
-    const std::string header) {
+const std::vector<std::string> &HttpRequest::GetHeader(std::string header) {
+  std::transform(header.begin(), header.end(), header.begin(), toupper);
   return headers_[header];
 }
 

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -64,7 +64,7 @@ class HttpRequest {
 
   // ========================================================================
   // Getter and Setter
-  const std::vector<std::string> &GetHeader(const std::string header);
+  const std::vector<std::string> &GetHeader(std::string header);
 
  private:
   ParsingPhase ParseRequestLine(utils::ByteVector &buffer);

--- a/srcs/http/http_response.cpp
+++ b/srcs/http/http_response.cpp
@@ -56,6 +56,13 @@ void HttpResponse::Write(int fd) const {
   WriteBody(fd);
 }
 
+void HttpResponse::Clear() {
+  status_ = OK;
+  headers_.clear();
+  status_line_.clear();
+  body_.clear();
+}
+
 void HttpResponse::WriteStatusLine(int fd) const {
   utils::PutStrFd(status_line_, fd);
   utils::PutStrFd(http::kCrlf, fd);

--- a/srcs/http/http_response.hpp
+++ b/srcs/http/http_response.hpp
@@ -42,6 +42,9 @@ class HttpResponse {
 
   void Write(int fd) const;
 
+  // すべてのメンバー変数を初期化する
+  void Clear();
+
  private:
   void WriteStatusLine(int fd) const;
   void WriteHeaders(int fd) const;

--- a/srcs/server/epoll.cpp
+++ b/srcs/server/epoll.cpp
@@ -1,6 +1,5 @@
 #include "server/epoll.hpp"
 
-#include <stdio.h>
 #include <unistd.h>
 
 #include <cassert>
@@ -160,7 +159,6 @@ std::vector<FdEventEvent> Epoll::RetrieveTimeouts() {
     FdEvent *fde = it->second;
     if (fde->state & kFdeTimeout &&
         current_time - fde->last_active > fde->timeout_ms) {
-      printf("fd(%d) is timeout!\n", fde->fd);
       FdEventEvent fdee;
       fdee.fde = fde;
       fdee.events = kFdeTimeout;

--- a/srcs/server/epoll.cpp
+++ b/srcs/server/epoll.cpp
@@ -121,7 +121,7 @@ void Epoll::Del(FdEvent *fde, unsigned int events) {
 }
 
 void Epoll::SetTimeout(FdEvent *fde, long timeout_ms) {
-  fde->state |= kFdeTimeout;
+  Set(fde, kFdeTimeout);
   fde->timeout_ms = timeout_ms;
   fde->last_active = utils::GetCurrentTimeMs();
 }

--- a/srcs/server/epoll.cpp
+++ b/srcs/server/epoll.cpp
@@ -161,7 +161,10 @@ std::vector<FdEventEvent> Epoll::RetrieveTimeouts() {
         current_time - fde->last_active > fde->timeout_ms) {
       FdEventEvent fdee;
       fdee.fde = fde;
-      fdee.events = kFdeTimeout;
+      // TCP FIN が送信したデータより早く来る場合があり､
+      // その対策として kFdeError で接続切断をするのではなく､
+      // read(conn_fd) の返り値が0(EOF)または-1(Error)だったら切断する｡
+      fdee.events = kFdeTimeout | kFdeRead;
       fdee_vec.push_back(fdee);
     }
   }

--- a/srcs/server/epoll.hpp
+++ b/srcs/server/epoll.hpp
@@ -89,7 +89,7 @@ class Epoll {
   // -1を指定すると1つ以上のイベントが利用可能になるまでブロックする｡
   Result<std::vector<FdEventEvent> > WaitEvents(int timeout_ms = 0);
 
-  // Timeout だった場合にタイムアウトイベントとして回収する｡
+  // Timeoutなfd取得し､FdEventEventを返す｡
   std::vector<FdEventEvent> RetrieveTimeouts();
 
  private:

--- a/srcs/server/epoll.hpp
+++ b/srcs/server/epoll.hpp
@@ -3,6 +3,7 @@
 
 #include <sys/epoll.h>
 
+#include <ctime>
 #include <map>
 #include <vector>
 
@@ -39,9 +40,8 @@ struct FdEvent {
   int fd;
   FdFunc func;
 
-  // TODO: Timeクラスを作ってタイムアウトを管理する
-  // Time timeout;
-  // Time last_active;
+  long timeout_ms;
+  long last_active;
 
   // 監視対象のFdeEvent
   unsigned int state;
@@ -81,22 +81,21 @@ class Epoll {
   void Add(FdEvent *fde, unsigned int events);
   void Del(FdEvent *fde, unsigned int events);
 
+  void SetTimeout(FdEvent *fde, long timeout_ms);
+
   // 利用可能なイベントをepoll_waitで取得し､FdEventEventを返す｡
   //
   // timeout は ms 単位｡
   // -1を指定すると1つ以上のイベントが利用可能になるまでブロックする｡
-  Result<std::vector<FdEventEvent> > WaitEvents(int timeout_ms = -1);
+  Result<std::vector<FdEventEvent> > WaitEvents(int timeout_ms = 0);
+
+  // Timeout だった場合にタイムアウトイベントとして回収する｡
+  std::vector<FdEventEvent> RetrieveTimeouts();
 
  private:
   // epoll instance が片方のみでcloseされるのを防ぐためコピー操作は禁止
   Epoll(const Epoll &rhs);
   Epoll &operator=(const Epoll &rhs);
-
-  // TODO: タイムアウトかどうかを判定
-  // WaitEvents 内で実行し､もしタイムアウトがあった場合は
-  // kFdeTimeout のようなオリジナルのイベントフラグを用いて
-  // ハンドラーにタイムアウトしたことを伝える｡
-  // bool IsTimeout(FdEvent *fde);
 };
 
 }  // namespace server

--- a/srcs/server/event_loop.cpp
+++ b/srcs/server/event_loop.cpp
@@ -18,7 +18,7 @@ int StartEventLoop(Epoll &epoll) {
       InvokeFdEvent(fde, events, &epoll);
     }
 
-    Result<std::vector<FdEventEvent> > result = epoll.WaitEvents(10);
+    Result<std::vector<FdEventEvent> > result = epoll.WaitEvents(0);
     if (result.IsErr()) {
       utils::ErrExit("WaitEvents");
     }

--- a/srcs/server/event_loop.cpp
+++ b/srcs/server/event_loop.cpp
@@ -10,7 +10,16 @@ namespace server {
 int StartEventLoop(Epoll &epoll) {
   // イベントループ
   while (1) {
-    Result<std::vector<FdEventEvent> > result = epoll.WaitEvents();
+    std::vector<FdEventEvent> timeouts = epoll.RetrieveTimeouts();
+    printf("timeout count: %ld\n", timeouts.size());
+    for (std::vector<FdEventEvent>::const_iterator it = timeouts.begin();
+         it != timeouts.end(); ++it) {
+      FdEvent *fde = it->fde;
+      unsigned int events = it->events;
+      InvokeFdEvent(fde, events, &epoll);
+    }
+
+    Result<std::vector<FdEventEvent> > result = epoll.WaitEvents(10);
     if (result.IsErr()) {
       utils::ErrExit("WaitEvents");
     }

--- a/srcs/server/event_loop.cpp
+++ b/srcs/server/event_loop.cpp
@@ -11,7 +11,6 @@ int StartEventLoop(Epoll &epoll) {
   // イベントループ
   while (1) {
     std::vector<FdEventEvent> timeouts = epoll.RetrieveTimeouts();
-    printf("timeout count: %ld\n", timeouts.size());
     for (std::vector<FdEventEvent>::const_iterator it = timeouts.begin();
          it != timeouts.end(); ++it) {
       FdEvent *fde = it->fde;

--- a/srcs/server/setup.cpp
+++ b/srcs/server/setup.cpp
@@ -52,8 +52,7 @@ void AddListenFds2Epoll(Epoll &epoll, config::Config &config,
        it != listen_fd_port_map.end(); ++it) {
     int listen_fd = it->first;
     std::string port = it->second;
-    Socket *listen_sock =
-        new Socket(listen_fd, Socket::ListenSock, port, config);
+    ListenSocket *listen_sock = new ListenSocket(listen_fd, port, config);
     FdEvent *fde =
         CreateFdEvent(listen_fd, HandleListenSocketEvent, listen_sock);
     epoll.Register(fde);

--- a/srcs/server/socket.cpp
+++ b/srcs/server/socket.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 #include <cassert>
+#include <deque>
 
 #include "utils/inet_sockets.hpp"
 
@@ -49,8 +50,12 @@ ConnSocket::ConnSocket(int fd, const std::string &port,
                        const config::Config &config)
     : Socket(fd, ListenSock, port, config) {}
 
-std::vector<http::HttpRequest> &ConnSocket::GetRequests() {
+std::deque<http::HttpRequest> &ConnSocket::GetRequests() {
   return requests_;
+}
+
+bool ConnSocket::HasParsedRequest() {
+  return !requests_.empty() && requests_.front().IsCorrectRequest();
 }
 
 http::HttpResponse &ConnSocket::GetResponse() {

--- a/srcs/server/socket.cpp
+++ b/srcs/server/socket.cpp
@@ -82,7 +82,8 @@ Result<ConnSocket *> ListenSocket::AcceptNewConnection() {
   if (conn_fd < 0) {
     return Error("accept");
   }
-  if (fcntl(conn_fd, F_SETFD, O_NONBLOCK) < 0) {
+  int flags = fcntl(conn_fd, F_GETFL, 0);
+  if (fcntl(conn_fd, F_SETFL, flags | O_NONBLOCK) < 0) {
     return Error("fcntl");
   }
 

--- a/srcs/server/socket.cpp
+++ b/srcs/server/socket.cpp
@@ -82,8 +82,9 @@ Result<ConnSocket *> ListenSocket::AcceptNewConnection() {
   if (conn_fd < 0) {
     return Error("accept");
   }
-  int flags = fcntl(conn_fd, F_GETFL, 0);
-  if (fcntl(conn_fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+  int flags;
+  if ((flags = fcntl(conn_fd, F_GETFL, 0)) < 0 ||
+      fcntl(conn_fd, F_SETFL, flags | O_NONBLOCK) < 0) {
     return Error("fcntl");
   }
 

--- a/srcs/server/socket.hpp
+++ b/srcs/server/socket.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVER_SOCKET_HPP_
 #define SERVER_SOCKET_HPP_
 
+#include <deque>
 #include <string>
 #include <vector>
 
@@ -54,14 +55,16 @@ class Socket {
 
 class ConnSocket : public Socket {
  private:
-  std::vector<http::HttpRequest> requests_;
+  std::deque<http::HttpRequest> requests_;
   http::HttpResponse response_;
   utils::ByteVector buffer_;
 
  public:
   ConnSocket(int fd, const std::string &port, const config::Config &config);
 
-  std::vector<http::HttpRequest> &GetRequests();
+  std::deque<http::HttpRequest> &GetRequests();
+
+  bool ConnSocket::HasParsedRequest();
 
   http::HttpResponse &GetResponse();
 

--- a/srcs/server/socket.hpp
+++ b/srcs/server/socket.hpp
@@ -11,7 +11,6 @@
 #include "utils/ByteVector.hpp"
 
 namespace server {
-
 using namespace result;
 
 // listen_fd の情報などを持たせたい｡
@@ -67,6 +66,9 @@ class ConnSocket : public Socket {
   http::HttpResponse &GetResponse();
 
   utils::ByteVector &GetBuffer();
+
+  // タイムアウトのデフォルト時間は30秒
+  static const long kDefaultTimeoutMs = 10 * 1000;
 
  private:
   ConnSocket();

--- a/srcs/server/socket.hpp
+++ b/srcs/server/socket.hpp
@@ -60,6 +60,9 @@ class ConnSocket : public Socket {
   utils::ByteVector buffer_;
 
  public:
+  // タイムアウトのデフォルト時間は30秒
+  static const long kDefaultTimeoutMs = 30 * 1000;
+
   ConnSocket(int fd, const std::string &port, const config::Config &config);
 
   std::deque<http::HttpRequest> &GetRequests();
@@ -69,9 +72,6 @@ class ConnSocket : public Socket {
   http::HttpResponse &GetResponse();
 
   utils::ByteVector &GetBuffer();
-
-  // タイムアウトのデフォルト時間は30秒
-  static const long kDefaultTimeoutMs = 10 * 1000;
 
  private:
   ConnSocket();

--- a/srcs/server/socket.hpp
+++ b/srcs/server/socket.hpp
@@ -60,8 +60,11 @@ class ConnSocket : public Socket {
   utils::ByteVector buffer_;
 
  public:
-  // タイムアウトのデフォルト時間は30秒
-  static const long kDefaultTimeoutMs = 30 * 1000;
+  // タイムアウトのデフォルト時間は5秒
+  // HTTP/1.1 では Connection: close が来るまでソケットを接続し続ける｡
+  // Nginx などでは5秒間クライアントからデータが来なければ
+  //   切断するのでそれに合わせる｡
+  static const long kDefaultTimeoutMs = 5 * 1000;
 
   ConnSocket(int fd, const std::string &port, const config::Config &config);
 

--- a/srcs/server/socket.hpp
+++ b/srcs/server/socket.hpp
@@ -64,7 +64,7 @@ class ConnSocket : public Socket {
 
   std::deque<http::HttpRequest> &GetRequests();
 
-  bool ConnSocket::HasParsedRequest();
+  bool HasParsedRequest();
 
   http::HttpResponse &GetResponse();
 

--- a/srcs/server/socket_event_handler.cpp
+++ b/srcs/server/socket_event_handler.cpp
@@ -26,7 +26,6 @@ void HandleConnSocketEvent(FdEvent *fde, unsigned int events, void *data,
   ConnSocket *conn_sock = reinterpret_cast<ConnSocket *>(data);
   bool should_close_conn = false;
 
-
   if (events & kFdeRead) {
     should_close_conn |= ProcessRequest(conn_sock);
   }
@@ -40,9 +39,6 @@ void HandleConnSocketEvent(FdEvent *fde, unsigned int events, void *data,
     epoll->Del(fde, kFdeWrite);
   }
 
-  // TCP FIN が送信したデータより早く来る場合があり､
-  // その対策として kFdeError で接続切断をするのではなく､
-  // read(conn_fd) の返り値が0(EOF)または-1(Error)だったら切断する｡
   if (should_close_conn || (events & kFdeTimeout)) {
     printf("Connection close\n");
     epoll->Unregister(fde);

--- a/srcs/server/socket_event_handler.cpp
+++ b/srcs/server/socket_event_handler.cpp
@@ -26,7 +26,6 @@ void HandleConnSocketEvent(FdEvent *fde, unsigned int events, void *data,
   ConnSocket *conn_sock = reinterpret_cast<ConnSocket *>(data);
   bool should_close_conn = false;
 
-  printf("Conn(%d) catch event %d\n", fde->fd, events);
 
   if (events & kFdeRead) {
     should_close_conn |= ProcessRequest(conn_sock);

--- a/srcs/server/socket_event_handler.cpp
+++ b/srcs/server/socket_event_handler.cpp
@@ -62,7 +62,7 @@ void HandleListenSocketEvent(FdEvent *fde, unsigned int events, void *data,
         CreateFdEvent(conn_sock->GetFd(), HandleConnSocketEvent, conn_sock);
     epoll->Register(fdevent);
     epoll->Add(fdevent, kFdeRead);
-    epoll->Add(fdevent, kFdeWrite);
+    epoll->SetTimeout(fdevent, ConnSocket::kDefaultTimeoutMs);
   }
 
   if (events & kFdeError) {

--- a/srcs/utils/time.cpp
+++ b/srcs/utils/time.cpp
@@ -1,0 +1,15 @@
+#include "time.hpp"
+
+#include <stdlib.h>
+#include <sys/time.h>
+
+namespace utils {
+
+long GetCurrentTimeMs() {
+  timeval tv;
+
+  gettimeofday(&tv, NULL);
+  return (tv.tv_sec * 1000 + tv.tv_usec / 1000);
+}
+
+}  // namespace utils

--- a/srcs/utils/time.hpp
+++ b/srcs/utils/time.hpp
@@ -1,0 +1,10 @@
+#ifndef UTILS_TIME_HPP_
+#define UTILS_TIME_HPP_
+
+namespace utils {
+
+long GetCurrentTimeMs();
+
+}  // namespace utils
+
+#endif


### PR DESCRIPTION
接続済みソケットから30秒間データが送られてこなかった場合､タイムアウトとしてソケット接続を切断するようにした｡

以下のようなロジックで切断を行う
- イベントループにて `Epoll.WaitEvents()` でブロッキングせず即時リターンする｡
- イベントループにて `Epoll.RetrieveTimeouts()` という関数で前回イベントを検知してから指定された時間イベントが発生していない `FdEvent` を取得する｡そして `events = kFdeTimeout` としてハンドラー関数を実行する｡

これに伴い関連する箇所の変更を行った｡
- `HttpRequests` を `std::vector` ではなく `std::deque` で保持する｡
- 最初から `kFdeRead` と `kFdeWrite` を通知するのではなく､パースが完了したリクエストがある場合のみ `kFdeWrite` の通知を受け取る｡

## テスト方法

- タイムアウトによる切断: `time curl -v -H "Connection: close" localhost:8080`
- `Connection: close` による切断: `time curl -v  localhost:8080`