### PR TITLE
リクエストのメンバ変数からコンフィグを消した

### DIFF
--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -18,9 +18,8 @@ std::pair<Chunk::ChunkStatus, Chunk> CheckChunkReceived(
     utils::ByteVector &buffer);
 }  // namespace
 
-HttpRequest::HttpRequest(const config::Config &config)
-    : config_(config),
-      method_(""),
+HttpRequest::HttpRequest()
+    : method_(""),
       path_(""),
       minor_version_(-1),
       headers_(),
@@ -31,8 +30,7 @@ HttpRequest::HttpRequest(const config::Config &config)
       is_chunked_(false) {}
 
 HttpRequest::HttpRequest(const HttpRequest &rhs)
-    : config_(rhs.config_),
-      method_(rhs.method_),
+    : method_(rhs.method_),
       path_(rhs.path_),
       minor_version_(rhs.minor_version_),
       headers_(rhs.headers_),

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -46,7 +46,6 @@ class HttpRequest {
     kError
   };
 
-  const config::Config &config_;
   std::string method_;
   std::string path_;
   int minor_version_;
@@ -63,7 +62,7 @@ class HttpRequest {
   // ソケットからはデータを細切れでしか受け取れないので一旦バッファに保管し､行ごとに処理する｡
 
  public:
-  HttpRequest(const config::Config &config);
+  HttpRequest();
   HttpRequest(const HttpRequest &rhs);
   HttpRequest &operator=(const HttpRequest &rhs);
   ~HttpRequest();
@@ -83,7 +82,6 @@ class HttpRequest {
   const utils::ByteVector &GetBody();
 
  private:
-  HttpRequest();
   ParsingPhase ParseRequestLine(utils::ByteVector &buffer);
   ParsingPhase ParseHeaderField(utils::ByteVector &buffer);
   ParsingPhase ParseBodySize();

--- a/srcs/server/socket_event_handler.cpp
+++ b/srcs/server/socket_event_handler.cpp
@@ -99,7 +99,7 @@ bool ProcessRequest(ConnSocket *socket) {
     while (1) {
       std::deque<http::HttpRequest> &requests = socket->GetRequests();
       if (requests.empty() || requests.back().IsParsed()) {
-        requests.push_back(http::HttpRequest(socket->GetConfig()));
+        requests.push_back(http::HttpRequest());
       }
       requests.back().ParseRequest(buffer);
       if (requests.back().IsCorrectStatus() == false) {

--- a/unit_test/cgi/cgi_request_test.cpp
+++ b/unit_test/cgi/cgi_request_test.cpp
@@ -10,7 +10,7 @@ namespace cgi {
 TEST(CgiRequestTest, DefaultTest) {
   config::Config conf;
   config::LocationConf location;
-  http::HttpRequest req(conf);
+  http::HttpRequest req;
 
   std::string request_path = "/cgi-bin/test-cgi";
   cgi::CgiRequest cgi(request_path, req, location);
@@ -24,7 +24,7 @@ TEST(CgiRequestTest, DefaultTest) {
 TEST(CgiRequestTest, QueryStringTest) {
   config::Config conf;
   config::LocationConf location;
-  http::HttpRequest req(conf);
+  http::HttpRequest req;
 
   {
     std::string expect_cgi_path_ = "/cgi-bin/test-cgi";
@@ -63,7 +63,7 @@ TEST(CgiRequestTest, QueryStringTest) {
 TEST(CgiRequestTest, ArgsTest) {
   config::Config conf;
   config::LocationConf location;
-  http::HttpRequest req(conf);
+  http::HttpRequest req;
 
   {
     std::string expect_cgi_path_ = "/cgi-bin/test-cgi";

--- a/unit_test/http/request_parser_test.cpp
+++ b/unit_test/http/request_parser_test.cpp
@@ -26,7 +26,7 @@ utils::ByteVector OpenFile(const std::string& name) {
 }
 
 TEST(RequestParserTest, KOFormatExistOBSfoldFirstHeader) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistOBSfoldFirstHeader.txt");
 
   req.ParseRequest(buf);
@@ -35,7 +35,7 @@ TEST(RequestParserTest, KOFormatExistOBSfoldFirstHeader) {
 }
 
 TEST(RequestParserTest, KOFormatExistOBSfold) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistOBSfold.txt");
 
   req.ParseRequest(buf);
@@ -44,7 +44,7 @@ TEST(RequestParserTest, KOFormatExistOBSfold) {
 }
 
 TEST(RequestParserTest, KOFormatExistSPAfterVersion) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPAfterVersion.txt");
 
   req.ParseRequest(buf);
@@ -53,7 +53,7 @@ TEST(RequestParserTest, KOFormatExistSPAfterVersion) {
 }
 
 TEST(RequestParserTest, KOFormatExistSPBeforeSpace) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPBeforeSpace.txt");
 
   req.ParseRequest(buf);
@@ -62,7 +62,7 @@ TEST(RequestParserTest, KOFormatExistSPBeforeSpace) {
 }
 
 TEST(RequestParserTest, KOFormatExistSPBetWeenMethodAndURL) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPBetWeenMethodAndURL.txt");
 
   req.ParseRequest(buf);
@@ -71,7 +71,7 @@ TEST(RequestParserTest, KOFormatExistSPBetWeenMethodAndURL) {
 }
 
 TEST(RequestParserTest, KOFormatExistSPBetWeenURLAndVersion) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPBetWeenURLAndVersion.txt");
 
   req.ParseRequest(buf);
@@ -80,7 +80,7 @@ TEST(RequestParserTest, KOFormatExistSPBetWeenURLAndVersion) {
 }
 
 TEST(RequestParserTest, KOFormatNotExistCRLF) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistCRLF.txt");
 
   req.ParseRequest(buf);
@@ -89,7 +89,7 @@ TEST(RequestParserTest, KOFormatNotExistCRLF) {
 }
 
 // TEST(RequestParserTest, KOFormatNotExistHostHeader) {
-//   http::HttpRequest req(default_conf);
+//   http::HttpRequest req;
 //   utils::ByteVector buf = OpenFile("KOFormatNotExistHostHeader.txt");
 
 //   req.ParseRequest(buf);
@@ -98,7 +98,7 @@ TEST(RequestParserTest, KOFormatNotExistCRLF) {
 // }
 
 TEST(RequestParserTest, KOFormatNotExistMethod) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistMethod.txt");
 
   req.ParseRequest(buf);
@@ -107,7 +107,7 @@ TEST(RequestParserTest, KOFormatNotExistMethod) {
 }
 
 TEST(RequestParserTest, KOFormatNotExistRequestLine) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistRequestLine.txt");
 
   req.ParseRequest(buf);
@@ -116,7 +116,7 @@ TEST(RequestParserTest, KOFormatNotExistRequestLine) {
 }
 
 TEST(RequestParserTest, KOFormatNotExistURL) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistURL.txt");
 
   req.ParseRequest(buf);
@@ -125,7 +125,7 @@ TEST(RequestParserTest, KOFormatNotExistURL) {
 }
 
 TEST(RequestParserTest, KOFormatNotExistVersion) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistVersion.txt");
 
   req.ParseRequest(buf);
@@ -134,7 +134,7 @@ TEST(RequestParserTest, KOFormatNotExistVersion) {
 }
 
 TEST(RequestParserTest, KOHeaderExistSPBeforeColon) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOHeaderExistSPBeforeColon.txt");
 
   req.ParseRequest(buf);
@@ -143,7 +143,7 @@ TEST(RequestParserTest, KOHeaderExistSPBeforeColon) {
 }
 
 TEST(RequestParserTest, KOHeaderExistTabBeforeColon) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOHeaderExistTabBeforeColon.txt");
 
   req.ParseRequest(buf);
@@ -152,7 +152,7 @@ TEST(RequestParserTest, KOHeaderExistTabBeforeColon) {
 }
 
 TEST(RequestParserTest, KOHeaderNotExistDquotePair) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOHeaderNotExistDquotePair.txt");
 
   req.ParseRequest(buf);
@@ -161,7 +161,7 @@ TEST(RequestParserTest, KOHeaderNotExistDquotePair) {
 }
 
 // TEST(RequestParserTest, KOMethodNotAllowd) {
-//   http::HttpRequest req(default_conf);
+//   http::HttpRequest req;
 //   utils::ByteVector buf = OpenFile("KOMethodNotAllowd.txt");
 
 //   req.ParseRequest(buf);
@@ -170,7 +170,7 @@ TEST(RequestParserTest, KOHeaderNotExistDquotePair) {
 // }
 
 // TEST(RequestParserTest, KOMethodNotImplemented) {
-//   http::HttpRequest req(default_conf);
+//   http::HttpRequest req;
 //   utils::ByteVector buf = OpenFile("KOMethodNotImplemented.txt");
 
 //   req.ParseRequest(buf);
@@ -179,7 +179,7 @@ TEST(RequestParserTest, KOHeaderNotExistDquotePair) {
 // }
 
 TEST(RequestParserTest, KOUnknownMethod) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOUnknownMethod.txt");
 
   req.ParseRequest(buf);
@@ -188,7 +188,7 @@ TEST(RequestParserTest, KOUnknownMethod) {
 }
 
 TEST(RequestParserTest, KOURLTooLong) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOURLTooLong.txt");
 
   req.ParseRequest(buf);
@@ -197,7 +197,7 @@ TEST(RequestParserTest, KOURLTooLong) {
 }
 
 TEST(RequestParserTest, KOVersioExistMultipleDot) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersioExistMultipleDot.txt");
 
   req.ParseRequest(buf);
@@ -206,7 +206,7 @@ TEST(RequestParserTest, KOVersioExistMultipleDot) {
 }
 
 TEST(RequestParserTest, KOVersioInvalidMinorLong) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersioInvalidMinorLong.txt");
 
   req.ParseRequest(buf);
@@ -215,7 +215,7 @@ TEST(RequestParserTest, KOVersioInvalidMinorLong) {
 }
 
 TEST(RequestParserTest, KOVersionInvalidMajorLong) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidMajorLong.txt");
 
   req.ParseRequest(buf);
@@ -224,7 +224,7 @@ TEST(RequestParserTest, KOVersionInvalidMajorLong) {
 }
 
 TEST(RequestParserTest, KOVersionInvalidMajorLower) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidMajorLower.txt");
 
   req.ParseRequest(buf);
@@ -233,7 +233,7 @@ TEST(RequestParserTest, KOVersionInvalidMajorLower) {
 }
 
 // TEST(RequestParserTest, KOVersionInvalidMajorUpper) {
-//   http::HttpRequest req(default_conf);
+//   http::HttpRequest req;
 //   utils::ByteVector buf = OpenFile("KOVersionInvalidMajorUpper.txt");
 
 //   req.ParseRequest(buf);
@@ -242,7 +242,7 @@ TEST(RequestParserTest, KOVersionInvalidMajorLower) {
 // }
 
 TEST(RequestParserTest, KOVersionInvalidPrefix) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidPrefix.txt");
 
   req.ParseRequest(buf);
@@ -251,7 +251,7 @@ TEST(RequestParserTest, KOVersionInvalidPrefix) {
 }
 
 TEST(RequestParserTest, KOVersioNotExistDot) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersioNotExistDot.txt");
 
   req.ParseRequest(buf);
@@ -260,7 +260,7 @@ TEST(RequestParserTest, KOVersioNotExistDot) {
 }
 
 TEST(RequestParserTest, OKCommaInDquote) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKCommaInDquote.txt");
 
   req.ParseRequest(buf);
@@ -269,7 +269,7 @@ TEST(RequestParserTest, OKCommaInDquote) {
 }
 
 TEST(RequestParserTest, OKCorrectNewLine) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKCorrectNewLine.txt");
 
   req.ParseRequest(buf);
@@ -278,7 +278,7 @@ TEST(RequestParserTest, OKCorrectNewLine) {
 }
 
 TEST(RequestParserTest, OKCorrect) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKCorrect.txt");
 
   req.ParseRequest(buf);
@@ -287,7 +287,7 @@ TEST(RequestParserTest, OKCorrect) {
 }
 
 TEST(RequestParserTest, OKHeaderDquoteStringEscape) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderDquoteStringEscape.txt");
 
   req.ParseRequest(buf);
@@ -296,7 +296,7 @@ TEST(RequestParserTest, OKHeaderDquoteStringEscape) {
 }
 
 TEST(RequestParserTest, OKHeaderDquoteString) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderDquoteString.txt");
 
   req.ParseRequest(buf);
@@ -305,7 +305,7 @@ TEST(RequestParserTest, OKHeaderDquoteString) {
 }
 
 TEST(RequestParserTest, OKHeaderExistOWSBeforeValue) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderExistOWSBeforeValue.txt");
 
   req.ParseRequest(buf);
@@ -314,7 +314,7 @@ TEST(RequestParserTest, OKHeaderExistOWSBeforeValue) {
 }
 
 TEST(RequestParserTest, OKHeaderExistOWSftrerValue) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderExistOWSftrerValue.txt");
 
   req.ParseRequest(buf);
@@ -323,7 +323,7 @@ TEST(RequestParserTest, OKHeaderExistOWSftrerValue) {
 }
 
 TEST(RequestParserTest, OKHeaderListMultipleLine) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderListMultipleLine.txt");
 
   req.ParseRequest(buf);
@@ -332,7 +332,7 @@ TEST(RequestParserTest, OKHeaderListMultipleLine) {
 }
 
 TEST(RequestParserTest, OKHeaderList) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderList.txt");
 
   req.ParseRequest(buf);
@@ -341,7 +341,7 @@ TEST(RequestParserTest, OKHeaderList) {
 }
 
 TEST(RequestParserTest, OKVersionMinorUpper) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKVersionMinorUpper.txt");
 
   req.ParseRequest(buf);
@@ -350,7 +350,7 @@ TEST(RequestParserTest, OKVersionMinorUpper) {
 }
 
 TEST(RequestParserTest, KOBodyChunkSizeTooLarge) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyChunkSizeTooLarge.txt");
 
   req.ParseRequest(buf);
@@ -359,7 +359,7 @@ TEST(RequestParserTest, KOBodyChunkSizeTooLarge) {
 }
 
 TEST(RequestParserTest, KOBodyInvalidChunkSizeLower) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyInvalidChunkSizeLower.txt");
 
   req.ParseRequest(buf);
@@ -368,7 +368,7 @@ TEST(RequestParserTest, KOBodyInvalidChunkSizeLower) {
 }
 
 TEST(RequestParserTest, KOBodyInvalidChunkSizeUpper) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyInvalidChunkSizeUpper.txt");
 
   req.ParseRequest(buf);
@@ -377,7 +377,7 @@ TEST(RequestParserTest, KOBodyInvalidChunkSizeUpper) {
 }
 
 TEST(RequestParserTest, KOBodyNotExistChunkSize) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyNotExistChunkSize.txt");
 
   req.ParseRequest(buf);
@@ -386,7 +386,7 @@ TEST(RequestParserTest, KOBodyNotExistChunkSize) {
 }
 
 TEST(RequestParserTest, KOFieldInvalidTransferEncoding) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFieldInvalidTransferEncoding.txt");
 
   req.ParseRequest(buf);
@@ -395,7 +395,7 @@ TEST(RequestParserTest, KOFieldInvalidTransferEncoding) {
 }
 
 TEST(RequestParserTest, OKBodyChunkSizeZero) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKBodyChunkSizeZero.txt");
 
   req.ParseRequest(buf);
@@ -408,7 +408,7 @@ TEST(RequestParserTest, OKBodyChunkSizeZero) {
 }
 
 TEST(RequestParserTest, OKBodyCorrectChunkHexadecimal) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKBodyCorrectChunkHexadecimal.txt");
 
   req.ParseRequest(buf);
@@ -425,7 +425,7 @@ TEST(RequestParserTest, OKBodyCorrectChunkHexadecimal) {
 }
 
 TEST(RequestParserTest, OKBodyCorrectChunk) {
-  http::HttpRequest req(default_conf);
+  http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKBodyCorrectChunk.txt");
 
   req.ParseRequest(buf);


### PR DESCRIPTION
ParseRequest内でしか使わないので引数で受け取ることにした