### PR TITLE
RequestのGetHeaderを修正

### DIFF
--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -288,9 +288,17 @@ bool HttpRequest::IsCorrectStatus() {
 
 // ========================================================================
 // Getter and Setter
-const std::vector<std::string> &HttpRequest::GetHeader(std::string header) {
+
+Result<const std::vector<std::string> &> HttpRequest::GetHeader(
+    std::string header) const {
   std::transform(header.begin(), header.end(), header.begin(), toupper);
-  return headers_[header];
+  for (HeaderMap::const_iterator it = headers_.begin(); it != headers_.end();
+       ++it) {
+    if (it->first == header) {
+      return it->second;
+    }
+  }
+  return Error();
 }
 
 HttpStatus HttpRequest::GetParseStatus() const {

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -13,10 +13,12 @@
 #include "http/types.hpp"
 #include "http_constants.hpp"
 #include "http_status.hpp"
+#include "result/result.hpp"
 #include "utils/ByteVector.hpp"
 #include "utils/string.hpp"
 
 namespace http {
+using namespace result;
 
 namespace method_strs {
 const std::string kGet = "GET";
@@ -78,7 +80,7 @@ class HttpRequest {
 
   // ========================================================================
   // Getter and Setter
-  const std::vector<std::string> &GetHeader(std::string header);
+  Result<const std::vector<std::string> &> GetHeader(std::string header) const;
   const utils::ByteVector &GetBody();
 
  private:

--- a/srcs/http/http_response.cpp
+++ b/srcs/http/http_response.cpp
@@ -298,9 +298,13 @@ const std::vector<std::string> &HttpResponse::GetHeader(
 }
 
 bool HttpResponse::IsRequestHasConnectionClose(HttpRequest &request) {
-  return std::find(request.GetHeader("Connection").begin(),
-                   request.GetHeader("Connection").end(),
-                   "close") != request.GetHeader("Connection").end();
+  Result<const http::HeaderMap::mapped_type &> header_res =
+      request.GetHeader("Connection");
+  if (header_res.IsErr())
+    return false;
+  const http::HeaderMap::mapped_type &header = header_res.Ok();
+
+  return std::find(header.begin(), header.end(), "close") != header.end();
 }
 
 }  // namespace http

--- a/srcs/server/socket_event_handler.cpp
+++ b/srcs/server/socket_event_handler.cpp
@@ -140,8 +140,8 @@ bool ProcessResponse(ConnSocket *socket, Epoll *epoll) {
   if (socket->HasParsedRequest()) {
     http::HttpRequest &request = requests.front();
 
-    const std::string &host =
-        request.GetHeader("Host").empty() ? "" : request.GetHeader("Host")[0];
+    // TODO vserverをリクエストから取得するようにする。
+    const std::string &host = request.GetHeader("Host").Ok()[0];
     const std::string &port = socket->GetPort();
 
     // ポートとHostヘッダーから VirtualServerConf を取得


### PR DESCRIPTION
[]演算子がでアクセスすると、存在しないヘッダーを作成してしまうため。
GetHeader["Host"]とかやると、Hostが無かった時は　size() = 0の要素が取得できてしまう
