### PR TITLE
TCPソケットが途中で切断された際にCGIプロセスも終了する

### DIFF
--- a/srcs/cgi/cgi_process.cpp
+++ b/srcs/cgi/cgi_process.cpp
@@ -113,6 +113,7 @@ void DeleteCgiProcess(Epoll *epoll, FdEvent *fde) {
   CgiProcess *cgi_process = reinterpret_cast<CgiProcess *>(fde->data);
 
   if (cgi_process->IsRemovable()) {
+    epoll->Unregister(fde);
     delete cgi_process;
   } else {
     epoll->Unregister(fde);
@@ -131,6 +132,11 @@ void CgiProcess::HandleCgiEvent(FdEvent *fde, unsigned int events, void *data,
 
   CgiRequest *cgi_request = cgi_process->cgi_request_;
   CgiResponse *cgi_response = cgi_process->cgi_response_;
+
+  if (cgi_process->IsRemovable()) {
+    DeleteCgiProcess(epoll, fde);
+    return;
+  }
 
   if (events & kFdeTimeout) {
     printf("Timeout CGI\n");

--- a/srcs/http/http_cgi_response.cpp
+++ b/srcs/http/http_cgi_response.cpp
@@ -14,10 +14,9 @@ HttpCgiResponse::HttpCgiResponse(const config::LocationConf *location,
 HttpCgiResponse::~HttpCgiResponse() {
   printf("HttpCgiResponse::~HttpCgiResponse\n");
   if (cgi_process_->IsRemovable()) {
-    fprintf(stderr, "delete cgi_process_\n");
+    epoll_->Unregister(cgi_process_->GetFde());
     delete cgi_process_;
   } else {
-    epoll_->Unregister(cgi_process_->GetFde());
     cgi_process_->SetIsRemovable(true);
   }
 }

--- a/srcs/server/epoll.cpp
+++ b/srcs/server/epoll.cpp
@@ -38,13 +38,13 @@ FdEventEvent CalculateFdEventEvent(FdEvent *fde, epoll_event epev) {
   }
   if (epev.events & (EPOLLERR | EPOLLHUP | EPOLLRDHUP)) {
     if (epev.events & EPOLLERR) {
-      printf("CalculateFdEventEvent: EPOLLERR\n");
+      printf("CalculateFdEventEvent(%d): EPOLLERR\n", fde->fd);
     }
     if (epev.events & EPOLLHUP) {
-      printf("CalculateFdEventEvent: EPOLLHUP\n");
+      printf("CalculateFdEventEvent(%d): EPOLLHUP\n", fde->fd);
     }
     if (epev.events & EPOLLRDHUP) {
-      printf("CalculateFdEventEvent: EPOLLRDHUP\n");
+      printf("CalculateFdEventEvent(%d): EPOLLRDHUP\n", fde->fd);
     }
     // EPOLLRDHUP は TCP FIN を受信した場合にフラグが立つが､
     // ネットワークの回線の都合で先に送ったデータよりも後に送った TCP FIN
@@ -98,7 +98,10 @@ void Epoll::Register(FdEvent *fde) {
 }
 
 void Epoll::Unregister(FdEvent *fde) {
-  assert(registered_fd_events_.find(fde->fd) != registered_fd_events_.end());
+  if (registered_fd_events_.find(fde->fd) == registered_fd_events_.end()) {
+    return;
+  }
+
   if (epoll_ctl(epfd_, EPOLL_CTL_DEL, fde->fd, NULL) < 0) {
     utils::ErrExit("Epoll::Unregister epoll_ctl");
   }


### PR DESCRIPTION
## 発生していたバグ

`curl -v http://localhost:49200/cgi-bin/cgi-timeout` にリクエストを送り､CGIスクリプトが標準出力(UNIXドメインソケット)に全データ書き込み終わり､その後webservによってタイムアウトでプロセスがKILLされるより前にクライアント側からTCPソケットを切断するとCGIプロセスが永遠にKILLされない｡

## 原因

- HttpCgiResponseのデストラクタ内でUnixDomainSocketのEpollによる監視を削除していたためタイムアウトイベントが発生しない状態になっていた｡
- `HandleCgiEvent()` で `IsRemovable()` を見ていなかった｡

## 解決

- HttpCgiResponseのデストラクタ内でUnixDomainSocketのEpollによる監視は削除しない｡ただし､`IsRemovable` だった時は監視する｡
- `HandleCgiEvent()` で `IsRemovable()` をチェックする｡
- `HandleCgiEvent()` でタイムアウトが検知された際に､それ移行 `HandleCgiEvent()` は実行されてほしくないので Unregister するのだが､`HttpCgiResponse` のデストラクタでも `IsRemovable()` が True の時 Unregister するので､ `Epoll.Unregister()` で存在しない fde (すでにUnregisterされたfdeも含む) が渡された場合にエラーではなく､何もしないという挙動に変更｡