### PR TITLE
ConfigParserで拒否する条件を追加

### DIFF
--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -248,6 +248,9 @@ void Parser::ParseErrorPageDirective(LocationConf &location) {
     UngetC();
     SkipSpaces();
     std::string arg = GetWord();
+    if (arg.empty()) {
+      throw ParserException("error_page can't find end semicolon;");
+    }
     args.push_back(arg);
   }
   UngetC();

--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -294,14 +294,15 @@ void Parser::ParseAutoindexDirective(LocationConf &location) {
   if (GetC() != ';') {
     throw ParserException("Can't find semicolon after autoindex directive.");
   }
+
+  if (location.GetIsCgi() && location.GetAutoIndex()) {
+    throw ParserException("'is_cgi on' and 'autoindex on' conflicts.");
+  }
 }
 
 void Parser::ParseIscgiDirective(LocationConf &location) {
   if (IsDirectiveSetInLocation("is_cgi")) {
     throw ParserException("is_cgi has already set.");
-  }
-  if (location.GetAutoIndex()) {
-    throw ParserException("is_cgi and 'autoindex on' conflicts.");
   }
   if (IsDirectiveSetInLocation("return")) {
     throw ParserException("is_cgi and return conflicts.");
@@ -314,6 +315,10 @@ void Parser::ParseIscgiDirective(LocationConf &location) {
   SkipSpaces();
   if (GetC() != ';') {
     throw ParserException("Can't find semicolon after is_cgi directive.");
+  }
+
+  if (location.GetIsCgi() && location.GetAutoIndex()) {
+    throw ParserException("'is_cgi on' and 'autoindex on' conflicts.");
   }
 }
 

--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+#include <algorithm>
 #include <cstdarg>
 #include <cstring>
 #include <fstream>
@@ -214,9 +215,6 @@ void Parser::ParseRootDirective(LocationConf &location) {
 }
 
 void Parser::ParseIndexDirective(LocationConf &location) {
-  if (IsDirectiveSetInLocation("index")) {
-    throw ParserException("index has already set.");
-  }
   if (IsDirectiveSetInLocation("return")) {
     throw ParserException("index and return conflicts.");
   }
@@ -225,6 +223,11 @@ void Parser::ParseIndexDirective(LocationConf &location) {
   while (!IsEofReached() && GetC() != ';') {
     UngetC();
     std::string filepath = GetWord();
+    if (std::find(location.GetIndexPages().begin(),
+                  location.GetIndexPages().end(),
+                  filepath) != location.GetIndexPages().end()) {
+      throw ParserException("index %s has already set.", filepath);
+    }
     location.AppendIndexPages(filepath);
     SkipSpaces();
   }

--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -227,16 +227,17 @@ void Parser::ParseErrorPageDirective(LocationConf &location) {
 
   std::string &error_page = args.back();
   for (size_t i = 0; i < args.size() - 1; ++i) {
-    if (!IsValidHttpStatusCode(args[i])) {
-      // TODO: HTTPステータスコードの範囲内かチェックするメソッドで検査する｡
-      throw ParserException("error_page directive arg isn't valid number.");
-    }
     http::HttpStatus status =
         static_cast<http::HttpStatus>(atoi(args[i].c_str()));
-    if (location.GetErrorPages().find(status) ==
-        location.GetErrorPages().end()) {
-      location.AppendErrorPages(status, error_page);
+    if (!http::StatusCodes::IsHttpStatus(status)) {
+      throw ParserException("error_page directive arg %lu isn't valid number.",
+                            status);
     }
+    if (location.GetErrorPages().find(status) !=
+        location.GetErrorPages().end()) {
+      throw ParserException("error_page %d has already set.", status);
+    }
+    location.AppendErrorPages(status, error_page);
   }
 
   SkipSpaces();

--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+#include <cstdarg>
 #include <cstring>
 #include <fstream>
 #include <sstream>
@@ -13,6 +14,7 @@
 #include "config/location_conf.hpp"
 #include "config/virtual_server_conf.hpp"
 #include "http/http_request.hpp"
+#include "http/http_status.hpp"
 #include "utils/string.hpp"
 
 namespace config {
@@ -91,7 +93,7 @@ void Parser::ParseServerBlock(Config &config) {
 
 void Parser::ParseListenDirective(VirtualServerConf &vserver) {
   if (!vserver.GetListenPort().empty()) {
-    throw ParserException("Port is empty.");
+    throw ParserException("Port has already set.");
   }
   SkipSpaces();
   std::string port = GetWord();
@@ -117,6 +119,7 @@ void Parser::ParseServerNameDirective(VirtualServerConf &vserver) {
 
 void Parser::ParseLocationBlock(VirtualServerConf &vserver,
                                 bool is_location_back) {
+  location_set_directives_.clear();
   LocationConf location;
   location.SetIsBackwardSearch(is_location_back);
   SkipSpaces();
@@ -154,6 +157,7 @@ void Parser::ParseLocationBlock(VirtualServerConf &vserver,
       throw ParserException("Unknown directive in Location block.");
     }
     SkipSpaces();
+    location_set_directives_.insert(directive);
   }
 
   vserver.AppendLocation(location);
@@ -173,6 +177,10 @@ void Parser::ParseAllowMethodDirective(LocationConf &location) {
 }
 
 void Parser::ParseClientMaxBodySizeDirective(LocationConf &location) {
+  if (IsDirectiveSetInLocation("client_max_body_size")) {
+    throw ParserException("client_max_body_size has already set.");
+  }
+
   SkipSpaces();
   std::string body_size_str = GetWord();
   Result<unsigned long> result = utils::Stoul(body_size_str);
@@ -189,6 +197,13 @@ void Parser::ParseClientMaxBodySizeDirective(LocationConf &location) {
 }
 
 void Parser::ParseRootDirective(LocationConf &location) {
+  if (IsDirectiveSetInLocation("root")) {
+    throw ParserException("root has already set.");
+  }
+  if (IsDirectiveSetInLocation("return")) {
+    throw ParserException("root and return conflicts.");
+  }
+
   SkipSpaces();
   std::string root = GetWord();
   location.SetRootDir(root);
@@ -199,6 +214,13 @@ void Parser::ParseRootDirective(LocationConf &location) {
 }
 
 void Parser::ParseIndexDirective(LocationConf &location) {
+  if (IsDirectiveSetInLocation("index")) {
+    throw ParserException("index has already set.");
+  }
+  if (IsDirectiveSetInLocation("return")) {
+    throw ParserException("index and return conflicts.");
+  }
+
   SkipSpaces();
   while (!IsEofReached() && GetC() != ';') {
     UngetC();
@@ -209,6 +231,9 @@ void Parser::ParseIndexDirective(LocationConf &location) {
 }
 
 void Parser::ParseErrorPageDirective(LocationConf &location) {
+  if (IsDirectiveSetInLocation("return")) {
+    throw ParserException("error_page and return conflicts.");
+  }
   SkipSpaces();
   // 最後のargがエラーページのfilepathになってる｡
   std::vector<std::string> args;
@@ -247,6 +272,13 @@ void Parser::ParseErrorPageDirective(LocationConf &location) {
 }
 
 void Parser::ParseAutoindexDirective(LocationConf &location) {
+  if (IsDirectiveSetInLocation("autoindex")) {
+    throw ParserException("autoindex has already set.");
+  }
+  if (IsDirectiveSetInLocation("return")) {
+    throw ParserException("autoindex and return conflicts.");
+  }
+
   SkipSpaces();
   std::string on_or_off = GetWord();
   bool is_autoindex_enabled = ParseOnOff(on_or_off);
@@ -258,6 +290,16 @@ void Parser::ParseAutoindexDirective(LocationConf &location) {
 }
 
 void Parser::ParseIscgiDirective(LocationConf &location) {
+  if (IsDirectiveSetInLocation("is_cgi")) {
+    throw ParserException("is_cgi has already set.");
+  }
+  if (location.GetAutoIndex()) {
+    throw ParserException("is_cgi and 'autoindex on' conflicts.");
+  }
+  if (IsDirectiveSetInLocation("return")) {
+    throw ParserException("is_cgi and return conflicts.");
+  }
+
   SkipSpaces();
   std::string on_or_off = GetWord();
   bool is_cgi = ParseOnOff(on_or_off);
@@ -269,6 +311,16 @@ void Parser::ParseIscgiDirective(LocationConf &location) {
 }
 
 void Parser::ParseReturnDirective(LocationConf &location) {
+  if (IsDirectiveSetInLocation("return")) {
+    throw ParserException("return has already set.");
+  }
+  if (IsDirectiveSetInLocation("is_cgi") ||
+      IsDirectiveSetInLocation("autoindex") ||
+      IsDirectiveSetInLocation("error_page") ||
+      IsDirectiveSetInLocation("index") || IsDirectiveSetInLocation("root")) {
+    throw ParserException(
+        "return can't belong to location with other directives");
+  }
   SkipSpaces();
   std::string url = GetWord();
   location.SetRedirectUrl(url);
@@ -408,8 +460,18 @@ bool Parser::IsEofReached() {
   return buf_idx_ >= file_content_.length();
 }
 
-Parser::ParserException::ParserException(const char *errmsg)
-    : errmsg_(errmsg) {}
+bool Parser::IsDirectiveSetInLocation(const std::string &directive) {
+  return location_set_directives_.find(directive) !=
+         location_set_directives_.end();
+}
+
+Parser::ParserException::ParserException(const char *errfmt, ...) {
+  va_list args;
+  va_start(args, errfmt);
+
+  vsnprintf(errmsg_, MAX_ERROR_LEN, errfmt, args);
+  va_end(args);
+}
 
 const char *Parser::ParserException::what() const throw() {
   return errmsg_;

--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -208,7 +208,7 @@ void Parser::ParseRootDirective(LocationConf &location) {
 
   SkipSpaces();
   std::string root = GetWord();
-  if (!IsAbsolutePath(root)) {
+  if (!utils::IsAbsolutePath(root)) {
     throw ParserException("root %s is invalid.", root.c_str());
   }
   location.SetRootDir(root);
@@ -463,10 +463,6 @@ bool Parser::IsValidHttpStatusCode(const std::string &code) {
 bool Parser::IsValidPort(const std::string &port) {
   Result<unsigned long> result = utils::Stoul(port);
   return result.IsOk() && result.Ok() <= kMaxPortNumber;
-}
-
-bool Parser::IsAbsolutePath(const std::string &path) {
-  return !path.empty() && path[0] == '/' && utils::IsValidPath(path);
 }
 
 bool Parser::ParseOnOff(const std::string &on_or_off) {

--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -262,6 +262,9 @@ void Parser::ParseErrorPageDirective(LocationConf &location) {
 
   std::string &error_page = args.back();
   for (size_t i = 0; i < args.size() - 1; ++i) {
+    if (!IsValidHttpStatusCode(args[i])) {
+      throw ParserException("error_page directive arg isn't valid number.");
+    }
     http::HttpStatus status =
         static_cast<http::HttpStatus>(atoi(args[i].c_str()));
     if (!http::StatusCodes::IsHttpStatus(status)) {

--- a/srcs/config/config_parser.hpp
+++ b/srcs/config/config_parser.hpp
@@ -134,6 +134,9 @@ class Parser {
   // portが符号なし整数であり､ポート番号の範囲に収まっているかチェックする
   bool IsValidPort(const std::string &port);
 
+  // 絶対パスかどうか
+  bool IsAbsolutePath(const std::string &path);
+
   // "on" なら true, "off" なら false を返す｡
   bool ParseOnOff(const std::string &on_or_off);
 

--- a/srcs/config/config_parser.hpp
+++ b/srcs/config/config_parser.hpp
@@ -134,9 +134,6 @@ class Parser {
   // portが符号なし整数であり､ポート番号の範囲に収まっているかチェックする
   bool IsValidPort(const std::string &port);
 
-  // 絶対パスかどうか
-  bool IsAbsolutePath(const std::string &path);
-
   // "on" なら true, "off" なら false を返す｡
   bool ParseOnOff(const std::string &on_or_off);
 

--- a/srcs/config/config_parser.hpp
+++ b/srcs/config/config_parser.hpp
@@ -14,6 +14,19 @@ namespace config {
 using namespace result;
 
 class Parser {
+ private:
+  std::string file_content_;
+  size_t buf_idx_;
+
+  std::set<std::string> location_set_directives_;
+
+  // ピリオドを含むドメイン全体の長さ
+  static const int kMaxDomainLength = 253;
+  // ドメインの各ラベル(ピリオド区切りの文字列)の最大長
+  static const int kMaxDomainLabelLength = 63;
+  // ポート番号の最大値
+  static const unsigned long kMaxPortNumber = 65535;
+
  public:
   Parser();
   Parser(const Parser &rhs);
@@ -30,12 +43,15 @@ class Parser {
   Config ParseConfig();
 
   class ParserException : public std::exception {
+   private:
+    static const int MAX_ERROR_LEN = 1024;
+
    public:
-    ParserException(const char *errmsg = "Parser error.");
+    ParserException(const char *errfmt = "Parser error.", ...);
     const char *what() const throw();
 
    private:
-    const char *errmsg_;
+    char errmsg_[MAX_ERROR_LEN];
   };
 
  private:
@@ -124,15 +140,8 @@ class Parser {
   // file_content_ をすべて読み込んだか
   bool IsEofReached();
 
-  std::string file_content_;
-  size_t buf_idx_;
-
-  // ピリオドを含むドメイン全体の長さ
-  static const int kMaxDomainLength = 253;
-  // ドメインの各ラベル(ピリオド区切りの文字列)の最大長
-  static const int kMaxDomainLabelLength = 63;
-  // ポート番号の最大値
-  static const unsigned long kMaxPortNumber = 65535;
+  // location_set_directives_を参照し､そのディレクティブが今見ているlocation内で既にセットされたかどうかを返す
+  bool IsDirectiveSetInLocation(const std::string &directive);
 };
 
 }  // namespace config

--- a/srcs/server/main.cpp
+++ b/srcs/server/main.cpp
@@ -31,6 +31,10 @@ int main(int argc, char const *argv[]) {
   } else {
     config = config::CreateSampleConfig();
   }
+  if (!config.IsValid()) {
+    std::cerr << "Config is invalid!!" << std::endl;
+    exit(EXIT_FAILURE);
+  }
   config.Print();
 
   Result<server::ListenFdPortMap> result = server::OpenLilstenFds(config);

--- a/srcs/utils/path.cpp
+++ b/srcs/utils/path.cpp
@@ -78,4 +78,8 @@ Result<std::string> NormalizePath(const std::string &path) {
   return (JoinPath(normalize));
 }
 
+bool IsAbsolutePath(const std::string &path) {
+  return !path.empty() && path[0] == '/' && utils::IsValidPath(path);
+}
+
 }  // namespace utils

--- a/srcs/utils/path.hpp
+++ b/srcs/utils/path.hpp
@@ -22,6 +22,9 @@ std::string JoinPath(const std::string &s1, const std::string &s2);
 bool IsValidPath(const std::string &path);
 Result<std::string> NormalizePath(const std::string &path);
 
+// 絶対パスかどうか
+bool IsAbsolutePath(const std::string &path);
+
 }  // namespace utils
 
 #endif

--- a/test/webserv_configurations/sample.conf
+++ b/test/webserv_configurations/sample.conf
@@ -18,7 +18,6 @@ server {
   location /cgi-bin {
     root /public/cgi-bin;
     allow_method GET;
-    autoindex on;
     is_cgi on;
   }
 

--- a/unit_test/config/parser_test.cpp
+++ b/unit_test/config/parser_test.cpp
@@ -557,4 +557,6 @@ TEST(ParserTest, ValidIpv4AddrInServername) {
   EXPECT_TRUE(config.GetVirtualServerConf("8080", "198.0.255.1") != NULL);
 }
 
+
+
 }  // namespace config

--- a/unit_test/config/parser_test.cpp
+++ b/unit_test/config/parser_test.cpp
@@ -537,6 +537,23 @@ TEST(ParserTest, HttpStatusInErrorPagesAreInvalid) {
         "}                                            ");
     EXPECT_THROW(parser.ParseConfig();, Parser::ParserException);
   }
+
+  {
+    // ステータスコードがオーバーフロー
+    Parser parser;
+    parser.LoadData(
+        "server {                                     "
+        "  listen 8080;                               "
+        "                                             "
+        "  location / {                               "
+        "    allow_method GET;                        "
+        "    root /var/www/html;                      "
+        "    index index.html;                        "
+        "    error_page 4294967700 NotFound.html;     "
+        "  }                                          "
+        "}                                            ");
+    EXPECT_THROW(parser.ParseConfig();, Parser::ParserException);
+  }
 }
 
 TEST(ParserTest, ValidIpv4AddrInServername) {

--- a/unit_test/config/parser_test.cpp
+++ b/unit_test/config/parser_test.cpp
@@ -677,6 +677,10 @@ const std::vector<std::string> ParserLocationKoVec = {
                 "  is_cgi on;                               "
                 "  autoindex on;                            "
                 "}                                          "),
+    // root が絶対パスじゃない
+    std::string("location / {                               "
+                "  root hoge/fuga;                          "
+                "}                                          "),
 };
 
 INSTANTIATE_TEST_SUITE_P(ParserKo, ParserLocationTestKo,


### PR DESCRIPTION
close #166
close #59 

- [x] return､ と autoindex､ is_cgi ､ index が両方設定されていたらエラー
- [x] listen, autoindex, is_cgi, return, root がすでに設定されているのに更に別の行で設定しようとした場合エラー
- [x] is_cgi on; と autoindex on; が共存してたらエラー
- [x] root が絶対パスじゃない
- [x] error_page にて対象HTTPステータスコードのエラーページファイルが既に設定済みだったらパースエラー