### PR TITLE
194 いきなりsocketをcloseせずにshutdownしてからcloseする

### DIFF
--- a/srcs/server/socket.cpp
+++ b/srcs/server/socket.cpp
@@ -48,7 +48,8 @@ ConnSocket::ConnSocket(int fd, const SocketAddress &server_addr,
                        const config::Config &config)
     : Socket(fd, server_addr, config),
       client_addr_(client_addr),
-      response_(NULL) {}
+      response_(NULL),
+      is_shutdown_(false) {}
 
 ConnSocket::~ConnSocket() {
   if (response_ != NULL) {
@@ -72,6 +73,14 @@ bool ConnSocket::HasParsedRequest() {
   return !requests_.empty() && requests_.front().IsResponsible();
 }
 
+void ConnSocket::ShutDown() {
+  timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  std::cout << "Shutdown at " << ts.tv_sec << ":" << ts.tv_nsec << std::endl;
+  shutdown(fd_, SHUT_RDWR);
+  SetIsShutdown(true);
+}
+
 http::HttpResponse *ConnSocket::GetResponse() {
   return response_;
 }
@@ -82,6 +91,15 @@ void ConnSocket::SetResponse(http::HttpResponse *response) {
 
 utils::ByteVector &ConnSocket::GetBuffer() {
   return buffer_;
+}
+
+bool ConnSocket::IsShutdown() {
+  return is_shutdown_;
+}
+
+void ConnSocket::SetIsShutdown(bool is_shutdown) {
+  std::cout << "Set shutdown " << std::boolalpha << is_shutdown << std::endl;
+  is_shutdown_ = is_shutdown;
 }
 
 // ========================================================================

--- a/srcs/server/socket.cpp
+++ b/srcs/server/socket.cpp
@@ -74,9 +74,6 @@ bool ConnSocket::HasParsedRequest() {
 }
 
 void ConnSocket::ShutDown() {
-  timespec ts;
-  clock_gettime(CLOCK_REALTIME, &ts);
-  std::cout << "Shutdown at " << ts.tv_sec << ":" << ts.tv_nsec << std::endl;
   shutdown(fd_, SHUT_RDWR);
   SetIsShutdown(true);
 }
@@ -98,7 +95,6 @@ bool ConnSocket::IsShutdown() {
 }
 
 void ConnSocket::SetIsShutdown(bool is_shutdown) {
-  std::cout << "Set shutdown " << std::boolalpha << is_shutdown << std::endl;
   is_shutdown_ = is_shutdown;
 }
 

--- a/srcs/server/socket.hpp
+++ b/srcs/server/socket.hpp
@@ -60,6 +60,9 @@ class ConnSocket : public Socket {
   http::HttpResponse *response_;
   utils::ByteVector buffer_;
 
+  // shutdown したかどうか
+  bool is_shutdown_;
+
  public:
   // タイムアウトのデフォルト時間は5秒
   // HTTP/1.1 では Connection: close が来るまでソケットを接続し続ける｡
@@ -77,9 +80,12 @@ class ConnSocket : public Socket {
   std::deque<http::HttpRequest> &GetRequests();
 
   bool HasParsedRequest();
+  void ShutDown();
 
   http::HttpResponse *GetResponse();
   void SetResponse(http::HttpResponse *response);
+  bool IsShutdown();
+  void SetIsShutdown(bool is_shutdown);
 
   utils::ByteVector &GetBuffer();
 

--- a/srcs/server/socket.hpp
+++ b/srcs/server/socket.hpp
@@ -61,6 +61,8 @@ class ConnSocket : public Socket {
   utils::ByteVector buffer_;
 
   // shutdown したかどうか
+  // サーバーから切る場合は shutdown() して FIN を送ったか
+  // クライアントから切る場合は FIN がサーバーに届いたか
   bool is_shutdown_;
 
  public:

--- a/srcs/server/socket_event_handler.cpp
+++ b/srcs/server/socket_event_handler.cpp
@@ -51,12 +51,15 @@ void HandleConnSocketEvent(FdEvent *fde, unsigned int events, void *data,
     epoll->Del(fde, kFdeWrite);
   }
 
-  if (should_close_conn || (events & kFdeTimeout)) {
+  if ((should_close_conn && conn_sock->IsShutdown()) ||
+      (events & kFdeTimeout)) {
     printf("Connection close\n");
     epoll->Unregister(fde);
     // conn_sock->fd の close は Socket のデストラクタで行うので不要｡
     delete conn_sock;
     delete fde;
+  } else if (should_close_conn && !conn_sock->IsShutdown()) {
+    conn_sock->ShutDown();
   }
 }
 
@@ -93,10 +96,9 @@ bool ProcessRequest(ConnSocket *socket) {
   unsigned char buf[BUF_SIZE];
   int conn_fd = socket->GetFd();
   int n = read(conn_fd, buf, sizeof(buf) - 1);
-  if (n <= 0) {  // EOF(Connection end) or Error
-                 // TODO ここいらないかも？
+  if (n <= 0) {  // EOF(TCP flag FIN) or Error
     printf("Connection end\n");
-    // 呼び出し元でepollから対象conn_fdを削除する｡
+    socket->SetIsShutdown(true);
     return true;
   } else {
     utils::ByteVector &buffer = socket->GetBuffer();


### PR DESCRIPTION
サーバーから接続を切る際に､いきなりソケットをcloseするとクライアントがまだ全てのデータを受信出来ていない可能性があるので､ `shutdown(SHUT_RDWR)` によって FIN をクライアントに送り､クライアントが全てのデータを受信した後､ クライアントが FIN ACK を返してきて､その後クライアントから FIN を受け取り､closeするようにした｡ このクライアントからの FIN は `read(conn_sock) == 0`  で確認出来る｡

[Transmission Control Protocol プロトコル操作](https://ja.wikipedia.org/wiki/Transmission_Control_Protocol#%E3%83%97%E3%83%AD%E3%83%88%E3%82%B3%E3%83%AB%E6%93%8D%E4%BD%9C)

