### PR TITLE
CGI出力のステータス部とヘッダー部のサイズが16KBを超える場合はエラー

### DIFF
--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -52,6 +52,10 @@ CgiResponse::~CgiResponse() {}
 
 CgiResponse::ResponseType CgiResponse::Parse(utils::ByteVector &buffer) {
   if (response_type_ == kNotIdentified) {
+    if (buffer.size() > kMaxStatusHeaderSize) {
+      return response_type_ = kParseError;
+    }
+
     // まだ response_type が決まっていない場合
     if (newline_chars_.empty() && DetermineNewlineChars(buffer).IsErr()) {
       // ヘッダーとボディの区切りが見つからない場合は kNotIdentified

--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -52,12 +52,12 @@ CgiResponse::~CgiResponse() {}
 
 CgiResponse::ResponseType CgiResponse::Parse(utils::ByteVector &buffer) {
   if (response_type_ == kNotIdentified) {
-    if (buffer.size() > kMaxStatusHeaderSize) {
-      return response_type_ = kParseError;
-    }
-
     // まだ response_type が決まっていない場合
     if (newline_chars_.empty() && DetermineNewlineChars(buffer).IsErr()) {
+      // ステータス部とヘッダー部の上限サイズを超えている場合はエラー
+      if (buffer.size() > kMaxStatusHeaderSize) {
+        return response_type_ = kParseError;
+      }
       // ヘッダーとボディの区切りが見つからない場合は kNotIdentified
       return response_type_ = kNotIdentified;
     }

--- a/srcs/cgi/cgi_response.hpp
+++ b/srcs/cgi/cgi_response.hpp
@@ -68,6 +68,10 @@ class CgiResponse {
   static const std::string kCharExceptCtlAndSeparator;
   static const std::string kQdtext;
 
+  // ステータス部とヘッダー部の最大サイズ
+  // 16KB は Nginx と同じ設定
+  static const unsigned long kMaxStatusHeaderSize = 16 * 1024;  // 16KB
+
   // 改行文字を決定する
   Result<void> DetermineNewlineChars(const utils::ByteVector &buffer);
 


### PR DESCRIPTION
ヘッダー部とボディ部の区切りが16KBを超えても出現しない場合はエラーとする｡
16KBはNginxがHTTPリクエストのステータス部とヘッダー部のデフォルト最大サイズである｡

## 試し方

```bash
#!/bin/bash
set -f

# echo "Content-type: text/plain; charset=iso-8859-1"
# echo

for i in {0..99999};
do
	echo -n "hoge"
done
```

のようなCGIスクリプトを作成､実行した際に､16KBを超えたタイミングでCGIスクリプトが終了し､500 InternalServerError が返ってくることが確認できる｡