### PR TITLE
cgi で write エラー が 発生していた問題を修正

### DIFF
--- a/srcs/cgi/cgi_request.cpp
+++ b/srcs/cgi/cgi_request.cpp
@@ -152,9 +152,7 @@ bool CgiRequest::ForkAndExecuteCgi() {
   int parentsock = sockfds[0];
   int childsock = sockfds[1];
 
-  int fd_flags;
-  if ((fd_flags = fcntl(parentsock, F_GETFL, 0)) < 0 ||
-      fcntl(parentsock, F_SETFL, fd_flags | O_NONBLOCK) < 0) {
+  if (AddNonBlockingOptToFd(parentsock) == false) {
     close(parentsock);
     close(childsock);
     return false;
@@ -184,6 +182,16 @@ bool CgiRequest::ForkAndExecuteCgi() {
     close(childsock);
     return true;
   }
+}
+
+bool CgiRequest::AddNonBlockingOptToFd(int fd) const {
+  int fd_flags;
+
+  if ((fd_flags = fcntl(fd, F_GETFL, 0)) < 0 ||
+      fcntl(fd, F_SETFL, fd_flags | O_NONBLOCK) < 0) {
+    return false;
+  }
+  return true;
 }
 
 void CgiRequest::ExecuteCgi() {

--- a/srcs/cgi/cgi_request.hpp
+++ b/srcs/cgi/cgi_request.hpp
@@ -55,6 +55,8 @@ class CgiRequest {
   // 返り値は無名ドメインソケットのfd
   bool ForkAndExecuteCgi();
 
+  bool AddNonBlockingOptToFd(int fd) const;
+
   // リクエストからCGIスクリプトに渡す変数を作成する
   void CreateCgiMetaVariablesFromHttpRequest(
       const server::ConnSocket *conn_sock, const http::HttpRequest &request,

--- a/test/public/cgi-bin/hogehogehoge-cgi
+++ b/test/public/cgi-bin/hogehogehoge-cgi
@@ -17,7 +17,7 @@ set -f
 echo "Content-type: text/plain; charset=iso-8859-1"
 echo
 
-for i in {0..99999};
+for i in {0..30000};
 do 
 	echo "hoge"
 done

--- a/test/public/cgi-bin/hogehogehoge-cgi
+++ b/test/public/cgi-bin/hogehogehoge-cgi
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# To permit this cgi, replace # on the first line above with the
+# appropriate #!/path/to/sh shebang, and set this script executable
+# with chmod 755.
+#
+# ***** !!! WARNING !!! *****
+# This script echoes the server environment variables and therefore
+# leaks information - so NEVER use it in a live server environment!
+# It is provided only for testing purpose.
+# Also note that it is subject to cross site scripting attacks on
+# MS IE and any other browser which fails to honor RFC2616. 
+
+# disable filename globbing
+set -f
+
+echo "Content-type: text/plain; charset=iso-8859-1"
+echo
+
+for i in {0..99999};
+do 
+	echo "hoge"
+done

--- a/test/py-test/test_case.py
+++ b/test/py-test/test_case.py
@@ -157,6 +157,8 @@ def cgi_simple_test():
         "/cgi-bin/simple-cgi", expect_port=cmd_args.APACHE_PORT, save_diff=True
     )
 
+    run_cmp_test("/cgi-bin/hogehogehoge-cgi", expect_port=cmd_args.APACHE_PORT)
+
     expect_res = res.response(404)
     run_test("/cgi-bin/notexist-cgi", expect_res, ck_body=False)
 


### PR DESCRIPTION
cgiプロセス 側の fd も ノンブロッキング になっており、
パイプが いっぱいの 状態だと cgiプロセス側 で write err が 発生
webserv 側の fd のみ ノンブロッキング 設定するようにした。

`curl 127.0.0.1:49200/cgi-bin/hogehogehoge-cgi`
で 試せる。

fcntl で エラーの 際に fork して実行する前に、エラー判定したいので、fork より前に設定している。
close の 処理とか ちょっとごちゃごちゃしてるので、別プルリクで リファクタ 投げます。
