### PR TITLE
listen host:port が指定できるようにする

### DIFF
--- a/srcs/config/config.cpp
+++ b/srcs/config/config.cpp
@@ -48,12 +48,14 @@ void Config::Print() const {
 }
 
 const VirtualServerConf *Config::GetVirtualServerConf(
-    const PortType listen_port, const std::string &server_name) const {
+    const std::string &listen_ip, const PortType listen_port,
+    const std::string &server_name) const {
   const VirtualServerConf *virtual_server_conf = NULL;
 
   for (VirtualServerConfVector::const_iterator it = servers_.begin();
        it != servers_.end(); ++it) {
-    if (it->GetListenPort() == listen_port) {
+    if ((listen_ip == "0.0.0.0" || it->GetListenIp() == listen_ip) &&
+        it->GetListenPort() == listen_port) {
       if (virtual_server_conf == NULL) {
         virtual_server_conf = &(*it);
       } else if (!virtual_server_conf->IsServerNameIncluded(server_name) &&

--- a/srcs/config/config.cpp
+++ b/srcs/config/config.cpp
@@ -54,7 +54,7 @@ const VirtualServerConf *Config::GetVirtualServerConf(
 
   for (VirtualServerConfVector::const_iterator it = servers_.begin();
        it != servers_.end(); ++it) {
-    if ((listen_ip == "0.0.0.0" || it->GetListenIp() == listen_ip) &&
+    if ((listen_ip == kAnyIpAddress || it->GetListenIp() == listen_ip) &&
         it->GetListenPort() == listen_port) {
       if (virtual_server_conf == NULL) {
         virtual_server_conf = &(*it);

--- a/srcs/config/config.hpp
+++ b/srcs/config/config.hpp
@@ -40,7 +40,8 @@ class Config {
   // listen_port と server_name を元に適切なバーチャルサーバを返す｡
   // 該当するバーチャルサーバがない場合はNULLを返す｡
   const VirtualServerConf *GetVirtualServerConf(
-      const PortType listen_port, const std::string &server_name) const;
+      const std::string &listen_ip, const PortType listen_port,
+      const std::string &server_name) const;
 
   // すべてのバーチャルサーバを保持するvectorへの参照を返す｡
   const VirtualServerConfVector &GetVirtualServerConfs() const;

--- a/srcs/config/config_parser.cpp
+++ b/srcs/config/config_parser.cpp
@@ -115,7 +115,7 @@ std::pair<std::string, std::string> Parser::SplitToIpAndPort(
     std::string port = ip_port.substr(ip_port.find(":") + 1);
     return std::make_pair(ip, port);
   } else {
-    return std::make_pair("0.0.0.0", ip_port);
+    return std::make_pair(kAnyIpAddress, ip_port);
   }
 }
 

--- a/srcs/config/config_parser.hpp
+++ b/srcs/config/config_parser.hpp
@@ -132,6 +132,16 @@ class Parser {
   // 正しいHTTPステータスコードか
   bool IsValidHttpStatusCode(const std::string &code);
 
+  // "<IP>:<Port>" もしくは "<Port>"
+  bool IsValidListenArgument(const std::string &word);
+
+  // <num>.<num>.<num>.<num> の形式か｡
+  // num は 0~255 の数字
+  bool IsValidIp(const std::string &ip);
+
+  std::pair<std::string, std::string> SplitToIpAndPort(
+      const std::string &ip_port);
+
   // portが符号なし整数であり､ポート番号の範囲に収まっているかチェックする
   bool IsValidPort(const std::string &port);
 

--- a/srcs/config/location_conf.cpp
+++ b/srcs/config/location_conf.cpp
@@ -54,33 +54,33 @@ bool LocationConf::IsValid() const {
 }
 
 void LocationConf::Print() const {
-  std::cout << "location " << path_pattern_ << " {\n";
-  std::cout << "is_backward_search: " << is_backward_search_ << ";\n";
-  std::cout << "allowed_methods:";
+  std::cout << "\tlocation " << path_pattern_ << " {\n";
+  std::cout << "\t\tis_backward_search: " << is_backward_search_ << ";\n";
+  std::cout << "\t\tallowed_methods:";
   for (std::set<std::string>::const_iterator it = allowed_methods_.begin();
        it != allowed_methods_.end(); ++it) {
     std::cout << " " << *it;
   }
   std::cout << ";\n";
-  std::cout << "client_max_body_size: " << client_max_body_size_ << "\n";
-  std::cout << "root_dir: " << root_dir_ << "\n";
-  std::cout << "index_pages:";
+  std::cout << "\t\tclient_max_body_size: " << client_max_body_size_ << "\n";
+  std::cout << "\t\troot_dir: " << root_dir_ << "\n";
+  std::cout << "\t\tindex_pages:";
   for (std::vector<std::string>::const_iterator it = index_pages_.begin();
        it != index_pages_.end(); ++it) {
     std::cout << " " << *it;
   }
   std::cout << ";\n";
-  std::cout << "is_cgi: " << is_cgi_ << "\n";
-  std::cout << "error_pages:";
+  std::cout << "\t\tis_cgi: " << is_cgi_ << "\n";
+  std::cout << "\t\terror_pages:";
   for (std::map<http::HttpStatus, std::string>::const_iterator it =
            error_pages_.begin();
        it != error_pages_.end(); ++it) {
     std::cout << " " << it->first << "=" << it->second;
   }
   std::cout << ";\n";
-  std::cout << "auto_index: " << auto_index_ << "\n";
-  std::cout << "redirect_url: " << redirect_url_ << "\n";
-  std::cout << "}\n";
+  std::cout << "\t\tauto_index: " << auto_index_ << "\n";
+  std::cout << "\t\tredirect_url: " << redirect_url_ << "\n";
+  std::cout << "\t}\n";
 }
 
 std::string LocationConf::GetPathPattern() const {

--- a/srcs/config/virtual_server_conf.cpp
+++ b/srcs/config/virtual_server_conf.cpp
@@ -5,7 +5,7 @@
 namespace config {
 
 VirtualServerConf::VirtualServerConf()
-    : listen_port_(), server_names_(), locations_() {}
+    : listen_ip_(), listen_port_(), server_names_(), locations_() {}
 
 VirtualServerConf::VirtualServerConf(const VirtualServerConf &rhs) {
   *this = rhs;
@@ -13,6 +13,7 @@ VirtualServerConf::VirtualServerConf(const VirtualServerConf &rhs) {
 
 VirtualServerConf &VirtualServerConf::operator=(const VirtualServerConf &rhs) {
   if (this != &rhs) {
+    listen_ip_ = rhs.listen_ip_;
     listen_port_ = rhs.listen_port_;
     server_names_ = rhs.server_names_;
     locations_ = rhs.locations_;
@@ -59,8 +60,16 @@ void VirtualServerConf::Print() const {
   std::cout << "}\n";
 }
 
+std::string VirtualServerConf::GetListenIp() const {
+  return listen_ip_;
+}
+
 PortType VirtualServerConf::GetListenPort() const {
   return listen_port_;
+}
+
+void VirtualServerConf::SetListenIp(std::string listen_ip) {
+  listen_ip_ = listen_ip;
 }
 
 void VirtualServerConf::SetListenPort(PortType listen_port) {

--- a/srcs/config/virtual_server_conf.cpp
+++ b/srcs/config/virtual_server_conf.cpp
@@ -42,10 +42,10 @@ bool VirtualServerConf::IsValid() const {
 void VirtualServerConf::Print() const {
   std::cout << "server {\n";
 
-  std::cout << "listen: " << listen_port_ << ";"
+  std::cout << "\tlisten: " << listen_ip_ << ":" << listen_port_ << ";"
             << "\n";
 
-  std::cout << "server_name:";
+  std::cout << "\tserver_name:";
   for (std::set<std::string>::const_iterator it = server_names_.begin();
        it != server_names_.end(); ++it) {
     std::cout << " " << *it;

--- a/srcs/config/virtual_server_conf.hpp
+++ b/srcs/config/virtual_server_conf.hpp
@@ -22,6 +22,7 @@ class VirtualServerConf {
   typedef std::set<std::string> ServerNamesSet;
 
  private:
+  std::string listen_ip_;
   PortType listen_port_;
   ServerNamesSet server_names_;
   LocationConfsVector locations_;
@@ -43,8 +44,10 @@ class VirtualServerConf {
   // Getter and Setter
   // ========================================================================
 
+  std::string GetListenIp() const;
   PortType GetListenPort() const;
 
+  void SetListenIp(std::string listen_ip);
   void SetListenPort(PortType listen_port);
 
   bool IsServerNameIncluded(std::string server_name) const;

--- a/srcs/config/virtual_server_conf.hpp
+++ b/srcs/config/virtual_server_conf.hpp
@@ -11,6 +11,8 @@
 
 namespace config {
 
+const std::string kAnyIpAddress = "0.0.0.0";
+
 // getaddrinfo()などの標準ライブラリのインターフェースに合わせている｡
 // サービス名("http")などは受け付けず､数値での指定のみ
 typedef std::string PortType;

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -85,7 +85,7 @@ class HttpRequest {
   int GetLocalRedirectCount() const;
 
   void ParseRequest(utils::ByteVector &buffer, const config::Config &conf,
-                    const config::PortType &port);
+                    const std::string &ip, const config::PortType &port);
   bool IsErrorRequest() const;
   bool IsResponsible() const;
 
@@ -99,8 +99,8 @@ class HttpRequest {
  private:
   ParsingPhase ParseRequestLine(utils::ByteVector &buffer);
   ParsingPhase ParseHeaderField(utils::ByteVector &buffer);
-  ParsingPhase LoadHeader(const config::Config &conf,
-                          const config::PortType &conn_sock);
+  ParsingPhase LoadHeader(const config::Config &conf, const std::string &ip,
+                          const config::PortType &port);
   ParsingPhase ParseBody(utils::ByteVector &buffer);
   HttpStatus InterpretMethod(const std::string &method);
   void DivideParamAsPath(const std::string &token);
@@ -115,7 +115,7 @@ class HttpRequest {
   ParsingPhase ParseChunkedBody(utils::ByteVector &buffer);
 
   HttpStatus DecideBodySize();
-  bool LoadVirtualServer(const config::Config &conf,
+  bool LoadVirtualServer(const config::Config &conf, const std::string &ip,
                          const config::PortType &port);
   bool LoadLocation();
   void PrintRequestInfo();

--- a/srcs/server/setup.cpp
+++ b/srcs/server/setup.cpp
@@ -22,20 +22,24 @@ void CloseAllFds(const std::vector<int> &listen_fds);
 }  // namespace
 
 Result<void> RegisterListenSockets(Epoll &epoll, const config::Config &config) {
-  std::set<config::PortType> used_ports;
+  std::set<config::PortType> used_ip_ports;
   std::vector<int> fds;
   const config::Config::VirtualServerConfVector &virtual_servers =
       config.GetVirtualServerConfs();
   for (config::Config::VirtualServerConfVector::const_iterator it =
            virtual_servers.begin();
        it != virtual_servers.end(); ++it) {
-    if (used_ports.find(it->GetListenPort()) != used_ports.end()) {
+    std::string ip_port = it->GetListenIp() + ":" + it->GetListenPort();
+    std::string port_any_ip = "0.0.0.0:" + it->GetListenPort();
+    if (used_ip_ports.find(ip_port) != used_ip_ports.end() ||
+        used_ip_ports.find(port_any_ip) != used_ip_ports.end()) {
       // The port has already binded
       continue;
     }
+
     SocketAddress socket_address;
-    Result<int> listen_res = utils::InetListen(it->GetListenPort().c_str(),
-                                               SOMAXCONN, &socket_address);
+    Result<int> listen_res = utils::InetListen(
+        it->GetListenIp(), it->GetListenPort(), SOMAXCONN, &socket_address);
     if (listen_res.IsErr()) {
       CloseAllFds(fds);
       return Error("RegisterListenSockets");
@@ -47,7 +51,7 @@ Result<void> RegisterListenSockets(Epoll &epoll, const config::Config &config) {
     epoll.Register(fde);
     epoll.Add(fde, kFdeRead);
 
-    used_ports.insert(it->GetListenPort());
+    used_ip_ports.insert(ip_port);
     fds.push_back(fd);
   }
   return Result<void>();

--- a/srcs/server/socket.cpp
+++ b/srcs/server/socket.cpp
@@ -103,7 +103,10 @@ void ConnSocket::SetIsShutdown(bool is_shutdown) {
 
 ListenSocket::ListenSocket(int fd, const SocketAddress &server_addr,
                            const config::Config &config)
-    : Socket(fd, server_addr, config) {}
+    : Socket(fd, server_addr, config) {
+  std::cout << "Listen at " << GetServerIp() << ":" << GetServerPort()
+            << std::endl;
+}
 
 Result<ConnSocket *> ListenSocket::AcceptNewConnection() {
   struct sockaddr_storage client_addr;

--- a/srcs/server/socket_event_handler.cpp
+++ b/srcs/server/socket_event_handler.cpp
@@ -110,6 +110,7 @@ bool ProcessRequest(ConnSocket *socket) {
         requests.push_back(http::HttpRequest());
       }
       requests.back().ParseRequest(buffer, socket->GetConfig(),
+                                   socket->GetServerIp(),
                                    socket->GetServerPort());
       if (requests.back().IsErrorRequest()) {
         buffer.clear();

--- a/srcs/utils/inet_sockets.cpp
+++ b/srcs/utils/inet_sockets.cpp
@@ -58,7 +58,7 @@ int InetConnect(const std::string &host, const std::string &service, int type) {
 }
 
 /* Public interfaces: InetBind() and InetListen() */
-static int InetPassiveSocket(const std::string &service, int type,
+static int InetPassiveSocket(const char *host, const char *service, int type,
                              server::SocketAddress *sockaddr, bool doListen,
                              int backlog) {
   struct addrinfo hints;
@@ -73,7 +73,7 @@ static int InetPassiveSocket(const std::string &service, int type,
   hints.ai_family = AF_UNSPEC; /* Allow IPv4 or IPv6 */
   hints.ai_flags = AI_PASSIVE; /* Use wildcadrd IP address */
 
-  s = getaddrinfo(NULL, service.c_str(), &hints, &result);
+  s = getaddrinfo(host, service, &hints, &result);
   if (s != 0)
     return -1;
 
@@ -115,18 +115,22 @@ static int InetPassiveSocket(const std::string &service, int type,
   return (rp == NULL) ? -1 : sfd;
 }
 
-Result<int> InetListen(const std::string &service, int backlog,
-                       server::SocketAddress *sockaddr) {
-  int fd = InetPassiveSocket(service, SOCK_STREAM, sockaddr, true, backlog);
+Result<int> InetListen(const std::string &host, const std::string &service,
+                       int backlog, server::SocketAddress *sockaddr) {
+  const char *host_cstr = host.empty() ? NULL : host.c_str();
+  int fd = InetPassiveSocket(host_cstr, service.c_str(), SOCK_STREAM, sockaddr,
+                             true, backlog);
   if (fd < 0) {
     return Error();
   }
   return fd;
 }
 
-Result<int> InetBind(const std::string &service, int type,
-                     server::SocketAddress *sockaddr) {
-  int fd = InetPassiveSocket(service, type, sockaddr, false, 0);
+Result<int> InetBind(const std::string &host, const std::string &service,
+                     int type, server::SocketAddress *sockaddr) {
+  const char *host_cstr = host.empty() ? NULL : host.c_str();
+  int fd =
+      InetPassiveSocket(host_cstr, service.c_str(), type, sockaddr, false, 0);
   if (fd < 0) {
     return Error();
   }

--- a/srcs/utils/inet_sockets.hpp
+++ b/srcs/utils/inet_sockets.hpp
@@ -41,8 +41,8 @@ int InetConnect(const std::string &host, const std::string &service, int type);
  * Return:
  *   ファイルディスクリプタ。 エラーの場合は-1を返す。
  */
-Result<int> InetListen(const std::string &service, int backlog,
-                       server::SocketAddress *sockaddr);
+Result<int> InetListen(const std::string &host, const std::string &service,
+                       int backlog, server::SocketAddress *sockaddr);
 
 /* typeに指定されたソケットを作成し、service､typeに指定されたポートのワイルドカードアドレスへバインドする｡
  * この関数はソケットを特定のアドレスへバインドするUDPサーバ､UDPクライアント用です｡
@@ -56,8 +56,8 @@ Result<int> InetListen(const std::string &service, int backlog,
  * Return:
  *   ファイルディスクリプタ。 エラーの場合は-1を返す。
  */
-Result<int> InetBind(const std::string &service, int type,
-                     server::SocketAddress *sockaddr);
+Result<int> InetBind(const std::string &host, const std::string &service,
+                     int type, server::SocketAddress *sockaddr);
 
 /* インターネットソケットアドレスを可読形式に変換します｡
  * "(hostname, port-number)"の形式の文字列を返す｡

--- a/unit_test/config/config_test.cpp
+++ b/unit_test/config/config_test.cpp
@@ -58,6 +58,23 @@ TEST(ConfigTest, ReturnNullIfThereIsNoCorrespondingPortNumber) {
 
   EXPECT_TRUE(config.GetVirtualServerConf(kAnyIpAddress, "10", "") == NULL);
 }
+
+// Host:Ip のように指定されているときに正しく取得できる
+TEST(ConfigTest, GetVirtualServerByHostIp) {
+  Config config = CreateTestConfig();
+
+  const VirtualServerConf *vserver = NULL;
+
+  vserver = config.GetVirtualServerConf("127.0.0.1", "4545", "");
+  EXPECT_TRUE(vserver != NULL);
+  EXPECT_EQ(vserver->GetLocation("/")->GetRootDir(), "/var/www/127_0_0_1_4545");
+
+  vserver = config.GetVirtualServerConf("127.0.0.2", "4545", "");
+  EXPECT_TRUE(vserver != NULL);
+  EXPECT_EQ(vserver->GetLocation("/")->GetRootDir(), "/var/www/127_0_0_2_4545");
+
+  vserver = config.GetVirtualServerConf("127.0.0.3", "4545", "");
+  EXPECT_TRUE(vserver == NULL);
 }
 
 }  // namespace config

--- a/unit_test/config/config_test.cpp
+++ b/unit_test/config/config_test.cpp
@@ -13,7 +13,7 @@ TEST(ConfigTest, GetVirtualServerByPort) {
   Config config = CreateTestConfig();
 
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "");
   EXPECT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->IsServerNameIncluded("localhost"));
 }
@@ -25,7 +25,7 @@ TEST(
   Config config = CreateTestConfig();
 
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "");
   EXPECT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->IsServerNameIncluded("localhost"));
 }
@@ -37,7 +37,7 @@ TEST(
   Config config = CreateTestConfig();
 
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "nothing.com");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "nothing.com");
   EXPECT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->IsServerNameIncluded("localhost"));
 }
@@ -47,7 +47,7 @@ TEST(ConfigTest, GetVirtualServerByPortAndServerName) {
   Config config = CreateTestConfig();
 
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "webserv.com");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "webserv.com");
   EXPECT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->IsServerNameIncluded("www.webserv.com"));
 }
@@ -56,7 +56,8 @@ TEST(ConfigTest, GetVirtualServerByPortAndServerName) {
 TEST(ConfigTest, ReturnNullIfThereIsNoCorrespondingPortNumber) {
   Config config = CreateTestConfig();
 
-  EXPECT_TRUE(config.GetVirtualServerConf("0.0.0.0", "10", "") == NULL);
+  EXPECT_TRUE(config.GetVirtualServerConf(kAnyIpAddress, "10", "") == NULL);
+}
 }
 
 }  // namespace config

--- a/unit_test/config/config_test.cpp
+++ b/unit_test/config/config_test.cpp
@@ -12,7 +12,8 @@ namespace config {
 TEST(ConfigTest, GetVirtualServerByPort) {
   Config config = CreateTestConfig();
 
-  const VirtualServerConf *vserver = config.GetVirtualServerConf("8080", "");
+  const VirtualServerConf *vserver =
+      config.GetVirtualServerConf("0.0.0.0", "8080", "");
   EXPECT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->IsServerNameIncluded("localhost"));
 }
@@ -23,7 +24,8 @@ TEST(
     GetTheFirstVirtualServerListedIfThereAreMultipleVirtualServerOnTheSamePort) {
   Config config = CreateTestConfig();
 
-  const VirtualServerConf *vserver = config.GetVirtualServerConf("8080", "");
+  const VirtualServerConf *vserver =
+      config.GetVirtualServerConf("0.0.0.0", "8080", "");
   EXPECT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->IsServerNameIncluded("localhost"));
 }
@@ -35,7 +37,7 @@ TEST(
   Config config = CreateTestConfig();
 
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("8080", "nothing.com");
+      config.GetVirtualServerConf("0.0.0.0", "8080", "nothing.com");
   EXPECT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->IsServerNameIncluded("localhost"));
 }
@@ -45,7 +47,7 @@ TEST(ConfigTest, GetVirtualServerByPortAndServerName) {
   Config config = CreateTestConfig();
 
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("8080", "webserv.com");
+      config.GetVirtualServerConf("0.0.0.0", "8080", "webserv.com");
   EXPECT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->IsServerNameIncluded("www.webserv.com"));
 }
@@ -54,7 +56,7 @@ TEST(ConfigTest, GetVirtualServerByPortAndServerName) {
 TEST(ConfigTest, ReturnNullIfThereIsNoCorrespondingPortNumber) {
   Config config = CreateTestConfig();
 
-  EXPECT_TRUE(config.GetVirtualServerConf("10", "") == NULL);
+  EXPECT_TRUE(config.GetVirtualServerConf("0.0.0.0", "10", "") == NULL);
 }
 
 }  // namespace config

--- a/unit_test/config/create_test_config.cpp
+++ b/unit_test/config/create_test_config.cpp
@@ -5,106 +5,97 @@
 namespace config {
 
 Config CreateTestConfig() {
-  Config config;
+  const std::string test_config =
+      "server {                                    "
+      "  listen 8080;                              "
+      "  server_name localhost;                    "
+      "                                            "
+      "  location / {                              "
+      "    allow_method GET;                       "
+      "    root /var/www/html;                     "
+      "    index index.html index.htm;             "
+      "    error_page 500 /server_error_page.html; "
+      "    error_page 404 403 /not_found.html;     "
+      "  }                                         "
+      "                                            "
+      "  location /upload {                        "
+      "    allow_method GET POST DELETE;           "
+      "    root /var/www/user_uploads;             "
+      "    client_max_body_size 1048576;           "
+      "    autoindex on;                           "
+      "  }                                         "
+      "                                            "
+      "  location /upload2 {                       "
+      "    allow_method GET POST DELETE;           "
+      "    root /var/www/user_uploads2;            "
+      "    client_max_body_size 1048576;           "
+      "    autoindex on;                           "
+      "  }                                         "
+      "}                                           "
+      "                                            "
+      "server {                                    "
+      "  listen 8080;                              "
+      "  server_name www.webserv.com webserv.com;  "
+      "                                            "
+      "  location / {                              "
+      "    root /var/www/html;                     "
+      "    index index.html;                       "
+      "  }                                         "
+      "                                            "
+      "  location /ab {                            "
+      "    allow_method GET POST DELETE;           "
+      "    root /var/www/ab;                       "
+      "  }                                         "
+      "                                            "
+      "  location_back .php {                      "
+      "    allow_method GET POST DELETE;           "
+      "    is_cgi on;                              "
+      "    root /home/nginx/cgi_bins;              "
+      "  }                                         "
+      "}                                           "
+      "                                            "
+      "server {                                    "
+      "  listen 8888;                              "
+      "  server_name localhost;                    "
+      "                                            "
+      "  location / {                              "
+      "    root /var/www/html;                     "
+      "    index index.html;                       "
+      "  }                                         "
+      "                                            "
+      "  location / {                              "
+      "    root /var/www/html2;                    "
+      "    index index.html;                       "
+      "  }                                         "
+      "}                                           "
+      "                                            "
+      "server {                                    "
+      "  listen 9090;                              "
+      "                                            "
+      "  location / {                              "
+      "    return http://localhost:8080/;          "
+      "  }                                         "
+      "}                                           "
+      "                                            "
+      "server {                                    "
+      "  listen 127.0.0.1:4545;                    "
+      "                                            "
+      "  location / {                              "
+      "    root /var/www/127_0_0_1_4545;           "
+      "  }                                         "
+      "}                                           "
+      "                                            "
+      "server {                                    "
+      "  listen 127.0.0.2:4545;                    "
+      "                                            "
+      "  location / {                              "
+      "    root /var/www/127_0_0_2_4545;           "
+      "  }                                         "
+      "}                                           ";
 
-  // server 1
-  VirtualServerConf vserver1;
-  vserver1.SetListenPort("8080");
-  vserver1.AppendServerName("localhost");
-
-  LocationConf location_v1_1;
-  location_v1_1.SetPathPattern("/");
-  location_v1_1.AppendAllowedMethod("GET");
-  location_v1_1.SetRootDir("/var/www/html");
-  location_v1_1.AppendIndexPages("index.html");
-  location_v1_1.AppendIndexPages("index.htm");
-  location_v1_1.AppendErrorPages(http::SERVER_ERROR, "/server_error_page.html");
-  location_v1_1.AppendErrorPages(http::NOT_FOUND, "/not_found.html");
-  location_v1_1.AppendErrorPages(http::FORBIDDEN, "/not_found.html");
-  vserver1.AppendLocation(location_v1_1);
-
-  LocationConf location_v1_2;
-  location_v1_2.SetPathPattern("/upload");
-  location_v1_2.AppendAllowedMethod("GET");
-  location_v1_2.AppendAllowedMethod("POST");
-  location_v1_2.AppendAllowedMethod("DELETE");
-  location_v1_2.SetRootDir("/var/www/user_uploads");
-  location_v1_2.SetClientMaxBodySize(1048576);
-  location_v1_2.SetAutoIndex(true);
-  vserver1.AppendLocation(location_v1_2);
-
-  LocationConf location_v1_3;
-  location_v1_3.SetPathPattern("/upload2");
-  location_v1_3.AppendAllowedMethod("GET");
-  location_v1_3.AppendAllowedMethod("POST");
-  location_v1_3.AppendAllowedMethod("DELETE");
-  location_v1_3.SetRootDir("/var/www/user_uploads2");
-  location_v1_3.SetClientMaxBodySize(1048576);
-  location_v1_3.SetAutoIndex(true);
-  vserver1.AppendLocation(location_v1_3);
-
-  config.AppendVirtualServerConf(vserver1);
-
-  // server 2
-  VirtualServerConf vserver2;
-  vserver2.SetListenPort("8080");
-  vserver2.AppendServerName("www.webserv.com");
-  vserver2.AppendServerName("webserv.com");
-
-  LocationConf location_v2_1;
-  location_v2_1.SetPathPattern("/");
-  location_v2_1.SetRootDir("/var/www/html");
-  location_v2_1.AppendIndexPages("index.html");
-  vserver2.AppendLocation(location_v2_1);
-
-  LocationConf location_v2_2;
-  location_v2_2.SetPathPattern("/ab");
-  location_v2_2.AppendAllowedMethod("GET");
-  location_v2_2.AppendAllowedMethod("POST");
-  location_v2_2.AppendAllowedMethod("DELETE");
-  location_v2_2.SetRootDir("/var/www/ab");
-  vserver2.AppendLocation(location_v2_2);
-
-  LocationConf location_v2_3;
-  location_v2_3.SetPathPattern(".php");
-  location_v2_3.SetIsBackwardSearch(true);
-  location_v2_3.AppendAllowedMethod("GET");
-  location_v2_3.AppendAllowedMethod("POST");
-  location_v2_3.AppendAllowedMethod("DELETE");
-  location_v2_3.SetIsCgi(true);
-  location_v2_3.SetRootDir("/home/nginx/cgi_bins");
-  vserver2.AppendLocation(location_v2_3);
-
-  config.AppendVirtualServerConf(vserver2);
-
-  // server 3
-  VirtualServerConf vserver3;
-  vserver3.SetListenPort("8888");
-  vserver3.AppendServerName("localhost");
-
-  LocationConf location_v3_1;
-  location_v3_1.SetPathPattern("/");
-  location_v3_1.SetRootDir("/var/www/html");
-  location_v3_1.AppendIndexPages("index.html");
-  vserver3.AppendLocation(location_v3_1);
-
-  LocationConf location_v3_2;
-  location_v3_2.SetPathPattern("/");
-  location_v3_2.SetRootDir("/var/www/html2");
-  location_v3_2.AppendIndexPages("index.html");
-  vserver3.AppendLocation(location_v3_2);
-
-  config.AppendVirtualServerConf(vserver3);
-
-  // server 4
-  VirtualServerConf vserver4;
-  vserver4.SetListenPort("9090");
-
-  LocationConf location_v4_1;
-  location_v4_1.SetRedirectUrl("http://localhost:8080/");
-  vserver4.AppendLocation(location_v4_1);
-
-  config.AppendVirtualServerConf(vserver4);
+  Parser parser;
+  parser.LoadData(test_config);
+  Config config = parser.ParseConfig();
 
   return config;
 }

--- a/unit_test/config/parser_test.cpp
+++ b/unit_test/config/parser_test.cpp
@@ -25,7 +25,7 @@ TEST(ParserTest, SimpleServer) {
   EXPECT_TRUE(config.IsValid());
 
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "");
   ASSERT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->GetListenPort() == "8080");
 
@@ -64,7 +64,7 @@ TEST(ParserTest, SimpleServerInOneLine) {
   EXPECT_TRUE(config.IsValid());
 
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "");
   ASSERT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->GetListenPort() == "8080");
 
@@ -103,7 +103,7 @@ TEST(ParserTest, EscapedChar) {
   config.Print();
 
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "");
   ASSERT_TRUE(vserver != NULL);
 
   const LocationConf *location = vserver->GetLocation("/");
@@ -135,7 +135,7 @@ TEST(ParserTest, MultipleValidServers) {
 
   {
     const VirtualServerConf *vserver =
-        config.GetVirtualServerConf("0.0.0.0", "80", "localhost");
+        config.GetVirtualServerConf(kAnyIpAddress, "80", "localhost");
     ASSERT_TRUE(vserver != NULL);
 
     {
@@ -193,7 +193,7 @@ TEST(ParserTest, MultipleValidServers) {
 
   {
     const VirtualServerConf *vserver =
-        config.GetVirtualServerConf("0.0.0.0", "80", "www.webserv.com");
+        config.GetVirtualServerConf(kAnyIpAddress, "80", "www.webserv.com");
     ASSERT_TRUE(vserver != NULL);
 
     {
@@ -243,7 +243,7 @@ TEST(ParserTest, MultipleValidServers) {
 
   {
     const VirtualServerConf *vserver =
-        config.GetVirtualServerConf("0.0.0.0", "8080", "");
+        config.GetVirtualServerConf(kAnyIpAddress, "8080", "");
     ASSERT_TRUE(vserver != NULL);
 
     const LocationConf *location = vserver->GetLocation("/");
@@ -260,7 +260,7 @@ TEST(ParserTest, MultipleValidServers) {
 
   {
     const VirtualServerConf *vserver =
-        config.GetVirtualServerConf("0.0.0.0", "9090", "");
+        config.GetVirtualServerConf(kAnyIpAddress, "9090", "");
     ASSERT_TRUE(vserver != NULL);
     const LocationConf *location = vserver->GetLocation("/");
     ASSERT_TRUE(location != NULL);
@@ -598,8 +598,8 @@ TEST(ParserTest, ValidIpv4AddrInServername) {
   Config config = parser.ParseConfig();
   EXPECT_TRUE(
       config.GetVirtualServerConfs()[0].IsServerNameIncluded("198.0.255.1"));
-  EXPECT_TRUE(config.GetVirtualServerConf("0.0.0.0", "8080", "198.0.255.1") !=
-              NULL);
+  EXPECT_TRUE(config.GetVirtualServerConf(kAnyIpAddress, "8080",
+                                          "198.0.255.1") != NULL);
 }
 
 TEST(ParserTest, ClientMaxBodySizeIsIntmax) {
@@ -617,7 +617,7 @@ TEST(ParserTest, ClientMaxBodySizeIsIntmax) {
       "}                                            ");
   Config config = parser.ParseConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "");
   const LocationConf *location = vserver->GetLocation("/");
   EXPECT_TRUE(config.IsValid());
   EXPECT_EQ(location->GetClientMaxBodySize(), INT_MAX);
@@ -638,7 +638,7 @@ TEST(ParserTest, ClientMaxBodySizeIsOverIntmax) {
       "}                                            ");
   Config config = parser.ParseConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "");
   const LocationConf *location = vserver->GetLocation("/");
   EXPECT_FALSE(config.IsValid());
 }
@@ -656,7 +656,7 @@ TEST(ParserTest, ServerNameAcceptDomainWithPort) {
       "}                                            ");
   Config config = parser.ParseConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "");
   EXPECT_TRUE(config.IsValid());
   EXPECT_TRUE(vserver->IsServerNameIncluded("localhost:49200"));
 }

--- a/unit_test/config/parser_test.cpp
+++ b/unit_test/config/parser_test.cpp
@@ -24,7 +24,8 @@ TEST(ParserTest, SimpleServer) {
   config.Print();
   EXPECT_TRUE(config.IsValid());
 
-  const VirtualServerConf *vserver = config.GetVirtualServerConf("8080", "");
+  const VirtualServerConf *vserver =
+      config.GetVirtualServerConf("0.0.0.0", "8080", "");
   ASSERT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->GetListenPort() == "8080");
 
@@ -62,7 +63,8 @@ TEST(ParserTest, SimpleServerInOneLine) {
   config.Print();
   EXPECT_TRUE(config.IsValid());
 
-  const VirtualServerConf *vserver = config.GetVirtualServerConf("8080", "");
+  const VirtualServerConf *vserver =
+      config.GetVirtualServerConf("0.0.0.0", "8080", "");
   ASSERT_TRUE(vserver != NULL);
   EXPECT_TRUE(vserver->GetListenPort() == "8080");
 
@@ -100,7 +102,8 @@ TEST(ParserTest, EscapedChar) {
   Config config = parser.ParseConfig();
   config.Print();
 
-  const VirtualServerConf *vserver = config.GetVirtualServerConf("8080", "");
+  const VirtualServerConf *vserver =
+      config.GetVirtualServerConf("0.0.0.0", "8080", "");
   ASSERT_TRUE(vserver != NULL);
 
   const LocationConf *location = vserver->GetLocation("/");
@@ -132,7 +135,7 @@ TEST(ParserTest, MultipleValidServers) {
 
   {
     const VirtualServerConf *vserver =
-        config.GetVirtualServerConf("80", "localhost");
+        config.GetVirtualServerConf("0.0.0.0", "80", "localhost");
     ASSERT_TRUE(vserver != NULL);
 
     {
@@ -190,7 +193,7 @@ TEST(ParserTest, MultipleValidServers) {
 
   {
     const VirtualServerConf *vserver =
-        config.GetVirtualServerConf("80", "www.webserv.com");
+        config.GetVirtualServerConf("0.0.0.0", "80", "www.webserv.com");
     ASSERT_TRUE(vserver != NULL);
 
     {
@@ -239,7 +242,8 @@ TEST(ParserTest, MultipleValidServers) {
   }
 
   {
-    const VirtualServerConf *vserver = config.GetVirtualServerConf("8080", "");
+    const VirtualServerConf *vserver =
+        config.GetVirtualServerConf("0.0.0.0", "8080", "");
     ASSERT_TRUE(vserver != NULL);
 
     const LocationConf *location = vserver->GetLocation("/");
@@ -255,7 +259,8 @@ TEST(ParserTest, MultipleValidServers) {
   }
 
   {
-    const VirtualServerConf *vserver = config.GetVirtualServerConf("9090", "");
+    const VirtualServerConf *vserver =
+        config.GetVirtualServerConf("0.0.0.0", "9090", "");
     ASSERT_TRUE(vserver != NULL);
     const LocationConf *location = vserver->GetLocation("/");
     ASSERT_TRUE(location != NULL);
@@ -268,6 +273,26 @@ TEST(ParserTest, MultipleValidServers) {
     EXPECT_TRUE(location->GetRedirectUrl() == "http://localhost:8080/");
     EXPECT_TRUE(config.IsValid());
   }
+}
+
+TEST(ParserTest, IpAndPort) {
+  Parser parser;
+  parser.LoadData(
+      "server {                                     "
+      "  listen 127.0.0.1:8080;                     "
+      "                                             "
+      "  location / {                               "
+      "    allow_method GET;                        "
+      "    index index.html;                        "
+      "    error_page 404 403 NotFound.html;        "
+      "  }                                          "
+      "}                                            ");
+  Config config = parser.ParseConfig();
+  const VirtualServerConf *vserver =
+      config.GetVirtualServerConf("127.0.0.1", "8080", "");
+  EXPECT_TRUE(vserver != NULL);
+  EXPECT_EQ(vserver->GetListenIp(), "127.0.0.1");
+  EXPECT_EQ(vserver->GetListenPort(), "8080");
 }
 
 TEST(ParserTest, ConfigFileIsNotFound) {
@@ -573,7 +598,8 @@ TEST(ParserTest, ValidIpv4AddrInServername) {
   Config config = parser.ParseConfig();
   EXPECT_TRUE(
       config.GetVirtualServerConfs()[0].IsServerNameIncluded("198.0.255.1"));
-  EXPECT_TRUE(config.GetVirtualServerConf("8080", "198.0.255.1") != NULL);
+  EXPECT_TRUE(config.GetVirtualServerConf("0.0.0.0", "8080", "198.0.255.1") !=
+              NULL);
 }
 
 TEST(ParserTest, ClientMaxBodySizeIsIntmax) {
@@ -590,7 +616,8 @@ TEST(ParserTest, ClientMaxBodySizeIsIntmax) {
       "  }                                          "
       "}                                            ");
   Config config = parser.ParseConfig();
-  const VirtualServerConf *vserver = config.GetVirtualServerConf("8080", "");
+  const VirtualServerConf *vserver =
+      config.GetVirtualServerConf("0.0.0.0", "8080", "");
   const LocationConf *location = vserver->GetLocation("/");
   EXPECT_TRUE(config.IsValid());
   EXPECT_EQ(location->GetClientMaxBodySize(), INT_MAX);
@@ -610,7 +637,8 @@ TEST(ParserTest, ClientMaxBodySizeIsOverIntmax) {
       "  }                                          "
       "}                                            ");
   Config config = parser.ParseConfig();
-  const VirtualServerConf *vserver = config.GetVirtualServerConf("8080", "");
+  const VirtualServerConf *vserver =
+      config.GetVirtualServerConf("0.0.0.0", "8080", "");
   const LocationConf *location = vserver->GetLocation("/");
   EXPECT_FALSE(config.IsValid());
 }
@@ -627,7 +655,8 @@ TEST(ParserTest, ServerNameAcceptDomainWithPort) {
       "  }                                          "
       "}                                            ");
   Config config = parser.ParseConfig();
-  const VirtualServerConf *vserver = config.GetVirtualServerConf("8080", "");
+  const VirtualServerConf *vserver =
+      config.GetVirtualServerConf("0.0.0.0", "8080", "");
   EXPECT_TRUE(config.IsValid());
   EXPECT_TRUE(vserver->IsServerNameIncluded("localhost:49200"));
 }

--- a/unit_test/config/virtual_server_conf_test.cpp
+++ b/unit_test/config/virtual_server_conf_test.cpp
@@ -12,7 +12,7 @@ namespace config {
 TEST(VirtualServerConfTest, GetLocationByForwardMatch) {
   Config config = CreateTestConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "localhost");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "localhost");
 
   {
     const LocationConf *location = vserver->GetLocation("/");
@@ -53,7 +53,7 @@ TEST(VirtualServerConfTest, GetLocationByForwardMatch) {
 TEST(VirtualServerConfTest, GetLocationByBackwardMatch) {
   Config config = CreateTestConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "www.webserv.com");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "www.webserv.com");
 
   {
     const LocationConf *location = vserver->GetLocation("/index.php");
@@ -71,7 +71,7 @@ TEST(VirtualServerConfTest, GetLocationByBackwardMatch) {
 TEST(VirtualServerConfTest, GetFirstLocationIfMultipleServerHaveSamePath) {
   Config config = CreateTestConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8888", "localhost");
+      config.GetVirtualServerConf(kAnyIpAddress, "8888", "localhost");
   const LocationConf *location = vserver->GetLocation("/");
   EXPECT_TRUE(location != NULL);
   EXPECT_TRUE(location->GetRootDir() == "/var/www/html");
@@ -81,7 +81,7 @@ TEST(VirtualServerConfTest, GetFirstLocationIfMultipleServerHaveSamePath) {
 TEST(VirtualServerConfTest, ReturnNullIfNoServerIsMatched) {
   Config config = CreateTestConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("0.0.0.0", "8080", "localhost");
+      config.GetVirtualServerConf(kAnyIpAddress, "8080", "localhost");
   const LocationConf *location =
       vserver->GetLocation("hogefuga");  // /が先頭についてない
   EXPECT_TRUE(location == NULL);

--- a/unit_test/config/virtual_server_conf_test.cpp
+++ b/unit_test/config/virtual_server_conf_test.cpp
@@ -12,7 +12,7 @@ namespace config {
 TEST(VirtualServerConfTest, GetLocationByForwardMatch) {
   Config config = CreateTestConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("8080", "localhost");
+      config.GetVirtualServerConf("0.0.0.0", "8080", "localhost");
 
   {
     const LocationConf *location = vserver->GetLocation("/");
@@ -53,7 +53,7 @@ TEST(VirtualServerConfTest, GetLocationByForwardMatch) {
 TEST(VirtualServerConfTest, GetLocationByBackwardMatch) {
   Config config = CreateTestConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("8080", "www.webserv.com");
+      config.GetVirtualServerConf("0.0.0.0", "8080", "www.webserv.com");
 
   {
     const LocationConf *location = vserver->GetLocation("/index.php");
@@ -71,7 +71,7 @@ TEST(VirtualServerConfTest, GetLocationByBackwardMatch) {
 TEST(VirtualServerConfTest, GetFirstLocationIfMultipleServerHaveSamePath) {
   Config config = CreateTestConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("8888", "localhost");
+      config.GetVirtualServerConf("0.0.0.0", "8888", "localhost");
   const LocationConf *location = vserver->GetLocation("/");
   EXPECT_TRUE(location != NULL);
   EXPECT_TRUE(location->GetRootDir() == "/var/www/html");
@@ -81,7 +81,7 @@ TEST(VirtualServerConfTest, GetFirstLocationIfMultipleServerHaveSamePath) {
 TEST(VirtualServerConfTest, ReturnNullIfNoServerIsMatched) {
   Config config = CreateTestConfig();
   const VirtualServerConf *vserver =
-      config.GetVirtualServerConf("8080", "localhost");
+      config.GetVirtualServerConf("0.0.0.0", "8080", "localhost");
   const LocationConf *location =
       vserver->GetLocation("hogefuga");  // /が先頭についてない
   EXPECT_TRUE(location == NULL);

--- a/unit_test/http/request_parser_test.cpp
+++ b/unit_test/http/request_parser_test.cpp
@@ -29,7 +29,7 @@ TEST(RequestParserTest, KOFormatExistOBSfoldFirstHeader) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistOBSfoldFirstHeader.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -38,7 +38,7 @@ TEST(RequestParserTest, KOFormatExistOBSfold) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistOBSfold.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -47,7 +47,7 @@ TEST(RequestParserTest, KOFormatExistSPAfterVersion) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPAfterVersion.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -56,7 +56,7 @@ TEST(RequestParserTest, KOFormatExistSPBeforeSpace) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPBeforeSpace.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -65,7 +65,7 @@ TEST(RequestParserTest, KOFormatExistSPBetWeenMethodAndURL) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPBetWeenMethodAndURL.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -74,7 +74,7 @@ TEST(RequestParserTest, KOFormatExistSPBetWeenURLAndVersion) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPBetWeenURLAndVersion.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -83,7 +83,7 @@ TEST(RequestParserTest, KOFormatNotExistCRLF) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistCRLF.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -92,7 +92,7 @@ TEST(RequestParserTest, KOFormatNotExistHostHeader) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistHostHeader.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -101,7 +101,7 @@ TEST(RequestParserTest, KOFormatExistMultipleHostHeader) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistMultipleHostHeader.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -110,7 +110,7 @@ TEST(RequestParserTest, KOFormatNotExistMethod) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistMethod.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -119,7 +119,7 @@ TEST(RequestParserTest, KOFormatNotExistRequestLine) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistRequestLine.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -128,7 +128,7 @@ TEST(RequestParserTest, KOFormatNotExistURL) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistURL.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -137,7 +137,7 @@ TEST(RequestParserTest, KOFormatNotExistVersion) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistVersion.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -146,7 +146,7 @@ TEST(RequestParserTest, KOHeaderExistSPBeforeColon) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOHeaderExistSPBeforeColon.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -155,7 +155,7 @@ TEST(RequestParserTest, KOHeaderExistTabBeforeColon) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOHeaderExistTabBeforeColon.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -164,7 +164,7 @@ TEST(RequestParserTest, KOHeaderNotExistDquotePair) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOHeaderNotExistDquotePair.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -175,7 +175,7 @@ TEST(RequestParserTest, KOMethodNotAllowd) {
   const config::Config not_allowed_conf =
       config::ParseConfig(kConfigurationDirPath + "NotAllowed.conf");
 
-  req.ParseRequest(buf, not_allowed_conf, "8080");
+  req.ParseRequest(buf, not_allowed_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), NOT_ALLOWED);
 }
@@ -184,7 +184,7 @@ TEST(RequestParserTest, KOUnknownMethod) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOUnknownMethod.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), NOT_IMPLEMENTED);
 }
@@ -193,7 +193,7 @@ TEST(RequestParserTest, KOURLTooLong) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOURLTooLong.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), URI_TOO_LONG);
 }
@@ -202,7 +202,7 @@ TEST(RequestParserTest, KOContentLengthTooLong) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOContentLengthTooLong.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), PAYLOAD_TOO_LARGE);
 }
@@ -211,7 +211,7 @@ TEST(RequestParserTest, KOVersioExistMultipleDot) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersioExistMultipleDot.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -220,7 +220,7 @@ TEST(RequestParserTest, KOVersioInvalidMinorLong) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersioInvalidMinorLong.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -229,7 +229,7 @@ TEST(RequestParserTest, KOVersionInvalidMajorLong) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidMajorLong.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -238,7 +238,7 @@ TEST(RequestParserTest, KOVersionInvalidMajorLower) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidMajorLower.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -247,7 +247,7 @@ TEST(RequestParserTest, KOVersionInvalidMajorUpper) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidMajorUpper.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), HTTP_VERSION_NOT_SUPPORTED);
 }
@@ -256,7 +256,7 @@ TEST(RequestParserTest, KOVersionInvalidPrefix) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidPrefix.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -265,7 +265,7 @@ TEST(RequestParserTest, KOVersioNotExistDot) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersioNotExistDot.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -274,7 +274,7 @@ TEST(RequestParserTest, OKCommaInDquote) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKCommaInDquote.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -283,7 +283,7 @@ TEST(RequestParserTest, OKCorrectNewLine) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKCorrectNewLine.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -294,7 +294,7 @@ TEST(RequestParserTest, KOLocationNotFound) {
   const config::Config conf =
       config::ParseConfig(kConfigurationDirPath + "LocationNotFound.conf");
 
-  req.ParseRequest(buf, conf, "8080");
+  req.ParseRequest(buf, conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), NOT_FOUND);
 }
@@ -303,7 +303,7 @@ TEST(RequestParserTest, OKCorrect) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKCorrect.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -312,7 +312,7 @@ TEST(RequestParserTest, OKHeaderDquoteStringEscape) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderDquoteStringEscape.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -321,7 +321,7 @@ TEST(RequestParserTest, OKHeaderDquoteString) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderDquoteString.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -330,7 +330,7 @@ TEST(RequestParserTest, OKHeaderExistOWSBeforeValue) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderExistOWSBeforeValue.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -339,7 +339,7 @@ TEST(RequestParserTest, OKHeaderExistOWSftrerValue) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderExistOWSftrerValue.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -348,7 +348,7 @@ TEST(RequestParserTest, OKHeaderListMultipleLine) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderListMultipleLine.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -357,7 +357,7 @@ TEST(RequestParserTest, OKHeaderList) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderList.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -366,7 +366,7 @@ TEST(RequestParserTest, OKVersionMinorUpper) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKVersionMinorUpper.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -375,7 +375,7 @@ TEST(RequestParserTest, KOBodyChunkSizeTooLarge) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyChunkSizeTooLarge.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), PAYLOAD_TOO_LARGE);
 }
@@ -384,7 +384,7 @@ TEST(RequestParserTest, KOBufferTooLarge) {
   http::HttpRequest req;
   utils::ByteVector buf(std::string(1024 * 1024 + 1, 'G'));
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -393,7 +393,7 @@ TEST(RequestParserTest, KOBodyInvalidChunkSizeLower) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyInvalidChunkSizeLower.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -402,7 +402,7 @@ TEST(RequestParserTest, KOBodyInvalidChunkSizeUpper) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyInvalidChunkSizeUpper.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -411,7 +411,7 @@ TEST(RequestParserTest, KOBodyNotExistChunkSize) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyNotExistChunkSize.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -420,7 +420,7 @@ TEST(RequestParserTest, KOFieldInvalidTransferEncoding) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFieldInvalidTransferEncoding.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), NOT_IMPLEMENTED);
 }
@@ -429,7 +429,7 @@ TEST(RequestParserTest, OKBodyChunkSizeZero) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKBodyChunkSizeZero.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 
@@ -442,7 +442,7 @@ TEST(RequestParserTest, OKBodyCorrectChunkHexadecimal) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKBodyCorrectChunkHexadecimal.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 
@@ -459,7 +459,7 @@ TEST(RequestParserTest, OKBodyCorrectChunk) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKBodyCorrectChunk.txt");
 
-  req.ParseRequest(buf, default_conf, "8080");
+  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 

--- a/unit_test/http/request_parser_test.cpp
+++ b/unit_test/http/request_parser_test.cpp
@@ -29,7 +29,7 @@ TEST(RequestParserTest, KOFormatExistOBSfoldFirstHeader) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistOBSfoldFirstHeader.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -38,7 +38,7 @@ TEST(RequestParserTest, KOFormatExistOBSfold) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistOBSfold.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -47,7 +47,7 @@ TEST(RequestParserTest, KOFormatExistSPAfterVersion) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPAfterVersion.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -56,7 +56,7 @@ TEST(RequestParserTest, KOFormatExistSPBeforeSpace) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPBeforeSpace.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -65,7 +65,7 @@ TEST(RequestParserTest, KOFormatExistSPBetWeenMethodAndURL) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPBetWeenMethodAndURL.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -74,7 +74,7 @@ TEST(RequestParserTest, KOFormatExistSPBetWeenURLAndVersion) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistSPBetWeenURLAndVersion.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -83,7 +83,7 @@ TEST(RequestParserTest, KOFormatNotExistCRLF) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistCRLF.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -92,7 +92,7 @@ TEST(RequestParserTest, KOFormatNotExistHostHeader) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistHostHeader.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -101,7 +101,7 @@ TEST(RequestParserTest, KOFormatExistMultipleHostHeader) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatExistMultipleHostHeader.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -110,7 +110,7 @@ TEST(RequestParserTest, KOFormatNotExistMethod) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistMethod.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -119,7 +119,7 @@ TEST(RequestParserTest, KOFormatNotExistRequestLine) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistRequestLine.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -128,7 +128,7 @@ TEST(RequestParserTest, KOFormatNotExistURL) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistURL.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -137,7 +137,7 @@ TEST(RequestParserTest, KOFormatNotExistVersion) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFormatNotExistVersion.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -146,7 +146,7 @@ TEST(RequestParserTest, KOHeaderExistSPBeforeColon) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOHeaderExistSPBeforeColon.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -155,7 +155,7 @@ TEST(RequestParserTest, KOHeaderExistTabBeforeColon) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOHeaderExistTabBeforeColon.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -164,7 +164,7 @@ TEST(RequestParserTest, KOHeaderNotExistDquotePair) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOHeaderNotExistDquotePair.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -175,7 +175,7 @@ TEST(RequestParserTest, KOMethodNotAllowd) {
   const config::Config not_allowed_conf =
       config::ParseConfig(kConfigurationDirPath + "NotAllowed.conf");
 
-  req.ParseRequest(buf, not_allowed_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, not_allowed_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), NOT_ALLOWED);
 }
@@ -184,7 +184,7 @@ TEST(RequestParserTest, KOUnknownMethod) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOUnknownMethod.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), NOT_IMPLEMENTED);
 }
@@ -193,7 +193,7 @@ TEST(RequestParserTest, KOURLTooLong) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOURLTooLong.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), URI_TOO_LONG);
 }
@@ -202,7 +202,7 @@ TEST(RequestParserTest, KOContentLengthTooLong) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOContentLengthTooLong.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), PAYLOAD_TOO_LARGE);
 }
@@ -211,7 +211,7 @@ TEST(RequestParserTest, KOVersioExistMultipleDot) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersioExistMultipleDot.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -220,7 +220,7 @@ TEST(RequestParserTest, KOVersioInvalidMinorLong) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersioInvalidMinorLong.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -229,7 +229,7 @@ TEST(RequestParserTest, KOVersionInvalidMajorLong) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidMajorLong.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -238,7 +238,7 @@ TEST(RequestParserTest, KOVersionInvalidMajorLower) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidMajorLower.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -247,7 +247,7 @@ TEST(RequestParserTest, KOVersionInvalidMajorUpper) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidMajorUpper.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), HTTP_VERSION_NOT_SUPPORTED);
 }
@@ -256,7 +256,7 @@ TEST(RequestParserTest, KOVersionInvalidPrefix) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersionInvalidPrefix.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -265,7 +265,7 @@ TEST(RequestParserTest, KOVersioNotExistDot) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOVersioNotExistDot.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -274,7 +274,7 @@ TEST(RequestParserTest, OKCommaInDquote) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKCommaInDquote.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -283,7 +283,7 @@ TEST(RequestParserTest, OKCorrectNewLine) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKCorrectNewLine.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -294,7 +294,7 @@ TEST(RequestParserTest, KOLocationNotFound) {
   const config::Config conf =
       config::ParseConfig(kConfigurationDirPath + "LocationNotFound.conf");
 
-  req.ParseRequest(buf, conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), NOT_FOUND);
 }
@@ -303,7 +303,7 @@ TEST(RequestParserTest, OKCorrect) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKCorrect.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -312,7 +312,7 @@ TEST(RequestParserTest, OKHeaderDquoteStringEscape) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderDquoteStringEscape.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -321,7 +321,7 @@ TEST(RequestParserTest, OKHeaderDquoteString) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderDquoteString.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -330,7 +330,7 @@ TEST(RequestParserTest, OKHeaderExistOWSBeforeValue) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderExistOWSBeforeValue.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -339,7 +339,7 @@ TEST(RequestParserTest, OKHeaderExistOWSftrerValue) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderExistOWSftrerValue.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -348,7 +348,7 @@ TEST(RequestParserTest, OKHeaderListMultipleLine) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderListMultipleLine.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -357,7 +357,7 @@ TEST(RequestParserTest, OKHeaderList) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKHeaderList.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -366,7 +366,7 @@ TEST(RequestParserTest, OKVersionMinorUpper) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKVersionMinorUpper.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 }
@@ -375,7 +375,7 @@ TEST(RequestParserTest, KOBodyChunkSizeTooLarge) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyChunkSizeTooLarge.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), PAYLOAD_TOO_LARGE);
 }
@@ -384,7 +384,7 @@ TEST(RequestParserTest, KOBufferTooLarge) {
   http::HttpRequest req;
   utils::ByteVector buf(std::string(1024 * 1024 + 1, 'G'));
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -393,7 +393,7 @@ TEST(RequestParserTest, KOBodyInvalidChunkSizeLower) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyInvalidChunkSizeLower.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -402,7 +402,7 @@ TEST(RequestParserTest, KOBodyInvalidChunkSizeUpper) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyInvalidChunkSizeUpper.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -411,7 +411,7 @@ TEST(RequestParserTest, KOBodyNotExistChunkSize) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOBodyNotExistChunkSize.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), BAD_REQUEST);
 }
@@ -420,7 +420,7 @@ TEST(RequestParserTest, KOFieldInvalidTransferEncoding) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("KOFieldInvalidTransferEncoding.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == true);
   EXPECT_EQ(req.GetParseStatus(), NOT_IMPLEMENTED);
 }
@@ -429,7 +429,7 @@ TEST(RequestParserTest, OKBodyChunkSizeZero) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKBodyChunkSizeZero.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 
@@ -442,7 +442,7 @@ TEST(RequestParserTest, OKBodyCorrectChunkHexadecimal) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKBodyCorrectChunkHexadecimal.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 
@@ -459,7 +459,7 @@ TEST(RequestParserTest, OKBodyCorrectChunk) {
   http::HttpRequest req;
   utils::ByteVector buf = OpenFile("OKBodyCorrectChunk.txt");
 
-  req.ParseRequest(buf, default_conf, "0.0.0.0", "8080");
+  req.ParseRequest(buf, default_conf, config::kAnyIpAddress, "8080");
   EXPECT_TRUE(req.IsErrorRequest() == false);
   EXPECT_EQ(req.GetParseStatus(), OK);
 


### PR DESCRIPTION
今までは `listen <port>` しか受け付けていなかったが､ `listen <host>:<port>` も受け入れられるようにした｡


`listen 8080` とすると `0.0.0.0:8080` で listen するようになる｡これは全てのネットワークインターフェースでlistenすることになる｡なので､ローカルネットワークに接続されているコンピュータで8080ポートが開いている場合は他のコンピュータからもアクセスできる｡

`listen 127.0.0.1:8080` とするとループバックアドレス `127.0.0.1` のポート `8080` でlistenする｡この場合はループバックアドレスようのインターフェース(`lo`)のみに割り当てられるため､外部からはアクセスできない｡

## 試し方

`test/configurations/sample.conf` に以下を追記

```


server {
  listen 127.0.0.2:9090;
  server_name localhost;

  location / {
    root /public;
    allow_method GET;
    autoindex on;
    is_cgi off;

    error_page 404 /public/error_pages/404.html;
  }
}

server {
  listen 127.0.0.3:9090;
  server_name localhost;

  location / {
    root /public;
    allow_method GET;
    autoindex on;
    is_cgi off;

    error_page 404 /public/error_pages/404.html;
  }
}
```

そして `make webserv-it` でコンテナに入り､以下のコマンドを叩く｡

- `curl http://127.0.0.1:9090` : 設定していないので接続できない
- `curl http://127.0.0.2:9090` : 接続できる
- `curl http://127.0.0.3:9090` : 接続できる