### PR TITLE
235 cgiが大量のデータを出力した後exitした時epollhupでcgiからのデータ読み込みが止まりクライアントに全データが送信されない

### DIFF
--- a/srcs/cgi/cgi_process.cpp
+++ b/srcs/cgi/cgi_process.cpp
@@ -164,7 +164,6 @@ bool CgiProcess::HandleCgiWriteEvent(CgiProcess *cgi_process, FdEvent *fde,
       write(cgi_request->GetCgiUnisock(), cgi_process->cgi_input_buffer_.data(),
             cgi_process->cgi_input_buffer_.size());
   if (write_res < 0) {
-    DeleteCgiProcess(epoll, fde);
     return true;
   }
   cgi_process->cgi_input_buffer_.EraseHead(write_res);

--- a/srcs/cgi/cgi_process.cpp
+++ b/srcs/cgi/cgi_process.cpp
@@ -130,9 +130,6 @@ void CgiProcess::HandleCgiEvent(FdEvent *fde, unsigned int events, void *data,
 
   CgiProcess *cgi_process = reinterpret_cast<CgiProcess *>(data);
 
-  CgiRequest *cgi_request = cgi_process->cgi_request_;
-  CgiResponse *cgi_response = cgi_process->cgi_response_;
-
   if (cgi_process->IsRemovable()) {
     DeleteCgiProcess(epoll, fde);
     return;
@@ -144,43 +141,53 @@ void CgiProcess::HandleCgiEvent(FdEvent *fde, unsigned int events, void *data,
     return;
   }
 
+  bool should_delete_cgi = false;
   if (events & kFdeWrite) {
-    // Write request's body to unisock
-    ssize_t write_res = write(cgi_request->GetCgiUnisock(),
-                              cgi_process->cgi_input_buffer_.data(),
-                              cgi_process->cgi_input_buffer_.size());
-    if (write_res < 0) {
-      DeleteCgiProcess(epoll, fde);
-      return;
-    }
-    cgi_process->cgi_input_buffer_.EraseHead(write_res);
-    if (cgi_process->cgi_input_buffer_.empty()) {
-      shutdown(cgi_request->GetCgiUnisock(), SHUT_WR);
-      epoll->Del(fde, kFdeWrite);
-    }
+    should_delete_cgi |= HandleCgiWriteEvent(cgi_process, fde, epoll);
   }
   if (events & kFdeRead) {
-    // Read data from unisock and store data in buffer
-    utils::Byte buf[kDataPerRead];
-    ssize_t read_res = read(cgi_request->GetCgiUnisock(), buf, kDataPerRead);
-    printf("HandleCgiEvent() read_res == %ld\n", read_res);
-    if (read_res < 0) {
-      DeleteCgiProcess(epoll, fde);
-      return;
-    }
-    if (read_res == 0) {
-      DeleteCgiProcess(epoll, fde);
-      return;
-    }
-    cgi_process->cgi_output_buffer_.AppendDataToBuffer(buf, read_res);
-    cgi_response->Parse(cgi_process->cgi_output_buffer_);
+    should_delete_cgi |= HandleCgiReadEvent(cgi_process);
   }
 
-  if (events & kFdeError) {
+  if (should_delete_cgi) {
     // Error
     DeleteCgiProcess(epoll, fde);
     return;
   }
+}
+
+bool CgiProcess::HandleCgiWriteEvent(CgiProcess *cgi_process, FdEvent *fde,
+                                     Epoll *epoll) {
+  CgiRequest *cgi_request = cgi_process->cgi_request_;
+  // Write request's body to unisock
+  ssize_t write_res =
+      write(cgi_request->GetCgiUnisock(), cgi_process->cgi_input_buffer_.data(),
+            cgi_process->cgi_input_buffer_.size());
+  if (write_res < 0) {
+    DeleteCgiProcess(epoll, fde);
+    return true;
+  }
+  cgi_process->cgi_input_buffer_.EraseHead(write_res);
+  if (cgi_process->cgi_input_buffer_.empty()) {
+    shutdown(cgi_request->GetCgiUnisock(), SHUT_WR);
+    epoll->Del(fde, kFdeWrite);
+  }
+  return false;
+}
+
+bool CgiProcess::HandleCgiReadEvent(CgiProcess *cgi_process) {
+  CgiRequest *cgi_request = cgi_process->cgi_request_;
+  CgiResponse *cgi_response = cgi_process->cgi_response_;
+  // Read data from unisock and store data in buffer
+  utils::Byte buf[kDataPerRead];
+  ssize_t read_res = read(cgi_request->GetCgiUnisock(), buf, kDataPerRead);
+  printf("HandleCgiEvent() read_res == %ld\n", read_res);
+  if (read_res <= 0) {
+    return true;
+  }
+  cgi_process->cgi_output_buffer_.AppendDataToBuffer(buf, read_res);
+  cgi_response->Parse(cgi_process->cgi_output_buffer_);
+  return false;
 }
 
 }  // namespace cgi

--- a/srcs/cgi/cgi_process.hpp
+++ b/srcs/cgi/cgi_process.hpp
@@ -66,9 +66,9 @@ class CgiProcess {
 
   static void HandleCgiEvent(FdEvent *fde, unsigned int events, void *data,
                              Epoll *epoll);
-  static Result<void> HandleCgiWriteEvent(CgiProcess *cgi_process, FdEvent *fde,
-                                          Epoll *epoll);
-  static Result<void> HandleCgiReadEvent(CgiProcess *cgi_process);
+  static bool HandleCgiWriteEvent(CgiProcess *cgi_process, FdEvent *fde,
+                                  Epoll *epoll);
+  static bool HandleCgiReadEvent(CgiProcess *cgi_process);
 };
 
 }  // namespace cgi

--- a/srcs/cgi/cgi_process.hpp
+++ b/srcs/cgi/cgi_process.hpp
@@ -66,6 +66,9 @@ class CgiProcess {
 
   static void HandleCgiEvent(FdEvent *fde, unsigned int events, void *data,
                              Epoll *epoll);
+  static bool HandleCgiWriteEvent(CgiProcess *cgi_process, FdEvent *fde,
+                                  Epoll *epoll);
+  static bool HandleCgiReadEvent(CgiProcess *cgi_process);
 };
 
 }  // namespace cgi

--- a/srcs/cgi/cgi_process.hpp
+++ b/srcs/cgi/cgi_process.hpp
@@ -66,9 +66,9 @@ class CgiProcess {
 
   static void HandleCgiEvent(FdEvent *fde, unsigned int events, void *data,
                              Epoll *epoll);
-  static bool HandleCgiWriteEvent(CgiProcess *cgi_process, FdEvent *fde,
-                                  Epoll *epoll);
-  static bool HandleCgiReadEvent(CgiProcess *cgi_process);
+  static Result<void> HandleCgiWriteEvent(CgiProcess *cgi_process, FdEvent *fde,
+                                          Epoll *epoll);
+  static Result<void> HandleCgiReadEvent(CgiProcess *cgi_process);
 };
 
 }  // namespace cgi

--- a/test/public/cgi-bin/toupper-cgi
+++ b/test/public/cgi-bin/toupper-cgi
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# To permit this cgi, replace # on the first line above with the
+# appropriate #!/path/to/sh shebang, and set this script executable
+# with chmod 755.
+#
+# ***** !!! WARNING !!! *****
+# This script echoes the server environment variables and therefore
+# leaks information - so NEVER use it in a live server environment!
+# It is provided only for testing purpose.
+# Also note that it is subject to cross site scripting attacks on
+# MS IE and any other browser which fails to honor RFC2616.
+
+# disable filename globbing
+set -f
+
+echo "Content-type: text/plain; charset=iso-8859-1"
+echo
+
+INPUT=`cat`
+
+echo TOUPPER
+echo
+echo input len ${#INPUT}
+echo
+echo ${INPUT^^}
+echo
+
+echo TOUPPER END


### PR DESCRIPTION
close #235 