### PR TITLE
232 cgi req の リファクタ

### DIFF
--- a/srcs/cgi/cgi_request.cpp
+++ b/srcs/cgi/cgi_request.cpp
@@ -165,7 +165,7 @@ bool CgiRequest::ForkAndExecuteCgi() {
 
 bool CgiRequest::CreateAndRunChildProcesses(int parentsock, int childsock) {
   cgi_pid_ = fork();
-  if (cgi_pid_ < -1) {
+  if (cgi_pid_ < 0) {
     return false;
   }
   if (cgi_pid_ == 0) {  // Child

--- a/srcs/cgi/cgi_request.cpp
+++ b/srcs/cgi/cgi_request.cpp
@@ -152,36 +152,34 @@ bool CgiRequest::ForkAndExecuteCgi() {
   int parentsock = sockfds[0];
   int childsock = sockfds[1];
 
-  if (AddNonBlockingOptToFd(parentsock) == false) {
+  if (AddNonBlockingOptToFd(parentsock) == false ||
+      CreateAndRunChildProcesses(parentsock, childsock) == false) {
     close(parentsock);
     close(childsock);
     return false;
   }
+  cgi_unisock_ = parentsock;
+  close(childsock);
+  return true;
+}
 
+bool CgiRequest::CreateAndRunChildProcesses(int parentsock, int childsock) {
   cgi_pid_ = fork();
   if (cgi_pid_ < -1) {
-    close(parentsock);
-    close(childsock);
     return false;
   }
-  if (cgi_pid_ == 0) {
-    // Child
+  if (cgi_pid_ == 0) {  // Child
     close(parentsock);
     if (dup2(childsock, STDIN_FILENO) < 0 ||
         dup2(childsock, STDOUT_FILENO) < 0) {
-      close(parentsock);
       close(childsock);
       exit(EXIT_FAILURE);
     }
     close(childsock);
     ExecuteCgi();
     exit(EXIT_FAILURE);
-  } else {
-    // Parent
-    cgi_unisock_ = parentsock;
-    close(childsock);
-    return true;
   }
+  return true;
 }
 
 bool CgiRequest::AddNonBlockingOptToFd(int fd) const {

--- a/srcs/cgi/cgi_request.hpp
+++ b/srcs/cgi/cgi_request.hpp
@@ -52,7 +52,6 @@ class CgiRequest {
                                     const std::vector<std::string> &v,
                                     const config::LocationConf &location);
 
-  // 返り値は無名ドメインソケットのfd
   bool ForkAndExecuteCgi();
   bool CreateAndRunChildProcesses(int parentsock, int childsock);
 

--- a/srcs/cgi/cgi_request.hpp
+++ b/srcs/cgi/cgi_request.hpp
@@ -54,6 +54,7 @@ class CgiRequest {
 
   // 返り値は無名ドメインソケットのfd
   bool ForkAndExecuteCgi();
+  bool CreateAndRunChildProcesses(int parentsock, int childsock);
 
   bool AddNonBlockingOptToFd(int fd) const;
 


### PR DESCRIPTION
- 子プロセス実行を別関数に切り分けた
- fork が エラーの際の返り値の条件ミスを修正した。