### PR TITLE
ReBindPathAndLocationを実装

### DIFF
--- a/srcs/http/http_cgi_response.cpp
+++ b/srcs/http/http_cgi_response.cpp
@@ -202,6 +202,7 @@ HttpRequest HttpCgiResponse::CreateLocalRedirectRequest(
 
   HttpRequest new_request(request);
   new_request.SetPath(location.Ok());
+  new_request.ReBindPathAndLocation();
   new_request.SetLocalRedirectCount(request.GetLocalRedirectCount() + 1);
   return new_request;
 }

--- a/srcs/http/http_cgi_response.cpp
+++ b/srcs/http/http_cgi_response.cpp
@@ -201,8 +201,7 @@ HttpRequest HttpCgiResponse::CreateLocalRedirectRequest(
   Result<std::string> location = cgi_response->GetHeader("LOCATION");
 
   HttpRequest new_request(request);
-  new_request.SetPath(location.Ok());
-  new_request.ReBindPathAndLocation();
+  new_request.ReBindPathAndLocation(location.Ok());
   new_request.SetLocalRedirectCount(request.GetLocalRedirectCount() + 1);
   return new_request;
 }

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -347,6 +347,26 @@ HttpStatus HttpRequest::InterpretTransferEncoding(
   }
 }
 
+void HttpRequest::ReBindPathAndLocation() {
+  parse_status_ = InterpretPath(path_);
+  if (parse_status_ != OK) {
+    phase_ = kError;
+    return;
+  }
+
+  if (LoadLocation() == false) {
+    parse_status_ = NOT_FOUND;
+    phase_ = kError;
+    return;
+  }
+
+  if (location_->IsMethodAllowed(method_) == false) {
+    parse_status_ = NOT_ALLOWED;
+    phase_ = kError;
+    return;
+  }
+}
+
 //========================================================================
 // Is系関数　外部から状態取得
 bool HttpRequest::IsResponsible() const {

--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -347,7 +347,8 @@ HttpStatus HttpRequest::InterpretTransferEncoding(
   }
 }
 
-void HttpRequest::ReBindPathAndLocation() {
+void HttpRequest::ReBindPathAndLocation(const std::string &new_path) {
+  path_ = new_path;
   parse_status_ = InterpretPath(path_);
   if (parse_status_ != OK) {
     phase_ = kError;

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -89,7 +89,7 @@ class HttpRequest {
   bool IsErrorRequest() const;
   bool IsResponsible() const;
 
-  void ReBindPathAndLocation();
+  void ReBindPathAndLocation(const std::string &new_path);
 
   // ========================================================================
   // Getter and Setter

--- a/srcs/http/http_request.hpp
+++ b/srcs/http/http_request.hpp
@@ -89,6 +89,8 @@ class HttpRequest {
   bool IsErrorRequest() const;
   bool IsResponsible() const;
 
+  void ReBindPathAndLocation();
+
   // ========================================================================
   // Getter and Setter
   std::string GetHttpVersion() const;


### PR DESCRIPTION
localredirect用リクエストを作った際、pathが変わるので、
pathの読み取りとlocationの割り当てを再度行う