### PR TITLE
バッファーの容量が大きくなると、処理に時間がかかるので、

### DIFF
--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -186,11 +186,11 @@ utils::ByteVector CgiResponse::ConvertToChunkResponse(utils::ByteVector data) {
 
 void CgiResponse::AppendLastChunk() {
   const std::string last_chunk = "0" + http::kCrlf + http::kCrlf;
-  body_.AppendDataToBuffer(last_chunk);
+  AppendBodyFromBuffer(last_chunk);
 }
 
 void CgiResponse::AppendBodyFromBuffer(const utils::ByteVector &buffer) {
-  body_.insert(body_.end(), buffer.begin(), buffer.end());
+  body_.AppendDataToBuffer(buffer);
 }
 
 void CgiResponse::AdjustHeadersBasedOnResponseType() {

--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -170,16 +170,14 @@ Result<void> CgiResponse::SetHeadersFromBuffer(utils::ByteVector &buffer) {
 }
 
 std::string ConvertToChunkResponse(utils::ByteVector data) {
-  const std::string kCrlf = "\r\n";
-  const unsigned long kMaxChunkSize = 1024;  // 1KB
   std::stringstream ss;
   while (data.empty() == false) {
     size_t chunk_size =
-        data.size() < kMaxChunkSize ? data.size() : kMaxChunkSize;
+        data.size() < http::kMaxUriLength ? data.size() : http::kMaxUriLength;
     ss << std::hex << chunk_size;
-    ss << kCrlf;
+    ss << http::kCrlf;
     ss << data.SubstrBeforePos(chunk_size);
-    ss << kCrlf;
+    ss << http::kCrlf;
     data.erase(data.begin(), data.begin() + chunk_size);
   }
   return ss.str();

--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -80,7 +80,7 @@ CgiResponse::ResponseType CgiResponse::Parse(utils::ByteVector &buffer) {
       return response_type_ = kParseError;
     }
     buffer = ConvertToChunkResponse(buffer);
-    AppendBodyFromBuffer(ConvertToChunkResponse(buffer););
+    AppendBodyFromBuffer(buffer);
   }
 
   return response_type_;

--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -79,8 +79,8 @@ CgiResponse::ResponseType CgiResponse::Parse(utils::ByteVector &buffer) {
       // response-body を保持することが許可されていないレスポンスタイプ
       return response_type_ = kParseError;
     }
-    buffer = ConvertToChunkResponse(buffer);
-    AppendBodyFromBuffer(buffer);
+    AppendBodyFromBuffer(ConvertToChunkResponse(buffer));
+    buffer.clear();
   }
 
   return response_type_;
@@ -189,9 +189,8 @@ void CgiResponse::AppendLastChunk() {
   body_.AppendDataToBuffer(last_chunk);
 }
 
-void CgiResponse::AppendBodyFromBuffer(utils::ByteVector &buffer) {
+void CgiResponse::AppendBodyFromBuffer(const utils::ByteVector &buffer) {
   body_.insert(body_.end(), buffer.begin(), buffer.end());
-  buffer.clear();
 }
 
 void CgiResponse::AdjustHeadersBasedOnResponseType() {

--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -169,7 +169,24 @@ Result<void> CgiResponse::SetHeadersFromBuffer(utils::ByteVector &buffer) {
   return Result<void>();
 }
 
+std::string ConvertToChunkResponse(utils::ByteVector data) {
+  const std::string kCrlf = "\r\n";
+  const unsigned long kMaxChunkSize = 1024;  // 1KB
+  std::stringstream ss;
+  while (data.empty() == false) {
+    size_t chunk_size =
+        data.size() < kMaxChunkSize ? data.size() : kMaxChunkSize;
+    ss << std::hex << chunk_size;
+    ss << kCrlf;
+    ss << data.SubstrBeforePos(chunk_size);
+    ss << kCrlf;
+    data.erase(data.begin(), data.begin() + chunk_size);
+  }
+  return ss.str();
+}
+
 void CgiResponse::SetBodyFromBuffer(utils::ByteVector &buffer) {
+  buffer = ConvertToChunkResponse(buffer);
   body_.insert(body_.end(), buffer.begin(), buffer.end());
   buffer.clear();
 }

--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -79,7 +79,8 @@ CgiResponse::ResponseType CgiResponse::Parse(utils::ByteVector &buffer) {
       // response-body を保持することが許可されていないレスポンスタイプ
       return response_type_ = kParseError;
     }
-    SetBodyFromBuffer(buffer);
+    buffer = ConvertToChunkResponse(buffer);
+    AppendBodyFromBuffer(ConvertToChunkResponse(buffer););
   }
 
   return response_type_;
@@ -169,7 +170,7 @@ Result<void> CgiResponse::SetHeadersFromBuffer(utils::ByteVector &buffer) {
   return Result<void>();
 }
 
-std::string ConvertToChunkResponse(utils::ByteVector data) {
+utils::ByteVector CgiResponse::ConvertToChunkResponse(utils::ByteVector data) {
   std::stringstream ss;
   while (data.empty() == false) {
     size_t chunk_size =
@@ -183,8 +184,12 @@ std::string ConvertToChunkResponse(utils::ByteVector data) {
   return ss.str();
 }
 
-void CgiResponse::SetBodyFromBuffer(utils::ByteVector &buffer) {
-  buffer = ConvertToChunkResponse(buffer);
+void CgiResponse::AppendLastChunk() {
+  const std::string last_chunk = "0" + http::kCrlf + http::kCrlf;
+  body_.AppendDataToBuffer(last_chunk);
+}
+
+void CgiResponse::AppendBodyFromBuffer(utils::ByteVector &buffer) {
   body_.insert(body_.end(), buffer.begin(), buffer.end());
   buffer.clear();
 }

--- a/srcs/cgi/cgi_response.hpp
+++ b/srcs/cgi/cgi_response.hpp
@@ -47,6 +47,9 @@ class CgiResponse {
   CgiResponse &operator=(const CgiResponse &rhs);
   ~CgiResponse();
 
+  utils::ByteVector ConvertToChunkResponse(utils::ByteVector data);
+  void AppendLastChunk();
+
   ResponseType Parse(utils::ByteVector &buffer);
 
   // ========================================================================
@@ -83,7 +86,7 @@ class CgiResponse {
   Result<void> SetHeadersFromBuffer(utils::ByteVector &buffer);
 
   // buffer の中身は body_ に移された後削除される
-  void SetBodyFromBuffer(utils::ByteVector &buffer);
+  void AppendBodyFromBuffer(utils::ByteVector &buffer);
 
   // response-type
   // によってはヘッダーにデフォルト値が設定されていたりするので､設定する

--- a/srcs/cgi/cgi_response.hpp
+++ b/srcs/cgi/cgi_response.hpp
@@ -86,7 +86,7 @@ class CgiResponse {
   Result<void> SetHeadersFromBuffer(utils::ByteVector &buffer);
 
   // buffer の中身は body_ に移された後削除される
-  void AppendBodyFromBuffer(utils::ByteVector &buffer);
+  void AppendBodyFromBuffer(const utils::ByteVector &buffer);
 
   // response-type
   // によってはヘッダーにデフォルト値が設定されていたりするので､設定する

--- a/srcs/cgi/cgi_response.hpp
+++ b/srcs/cgi/cgi_response.hpp
@@ -85,7 +85,6 @@ class CgiResponse {
   // ヘッダーとボディの区切りまでを buffer から削除する
   Result<void> SetHeadersFromBuffer(utils::ByteVector &buffer);
 
-  // buffer の中身は body_ に移された後削除される
   void AppendBodyFromBuffer(const utils::ByteVector &buffer);
 
   // response-type

--- a/srcs/http/http_cgi_response.cpp
+++ b/srcs/http/http_cgi_response.cpp
@@ -72,7 +72,6 @@ HttpCgiResponse::MakeResponseBody() {
   } else {
     utils::ByteVector &cgi_response_body =
         cgi_process_->GetCgiResponse()->GetBody();
-    // write_buffer_.AppendDataToBuffer(ConvertToChunkResponse(cgi_response_body));
     write_buffer_.AppendDataToBuffer(cgi_response_body);
     cgi_response_body.clear();
 
@@ -83,20 +82,6 @@ HttpCgiResponse::MakeResponseBody() {
       return kBody;
     }
   }
-}
-
-std::string HttpCgiResponse::ConvertToChunkResponse(utils::ByteVector data) {
-  std::stringstream ss;
-  while (data.empty() == false) {
-    size_t chunk_size =
-        data.size() < kMaxChunkSize ? data.size() : kMaxChunkSize;
-    ss << std::hex << chunk_size;
-    ss << kCrlf;
-    ss << data.SubstrBeforePos(chunk_size);
-    ss << kCrlf;
-    data.erase(data.begin(), data.begin() + chunk_size);
-  }
-  return ss.str();
 }
 
 HttpCgiResponse::CreateResponsePhase HttpCgiResponse::MakeDocumentResponse(

--- a/srcs/http/http_cgi_response.cpp
+++ b/srcs/http/http_cgi_response.cpp
@@ -4,8 +4,6 @@
 
 namespace http {
 
-const std::string HttpCgiResponse::kLastChunk = "0" + kCrlf + kCrlf;
-
 HttpCgiResponse::HttpCgiResponse(const config::LocationConf *location,
                                  server::Epoll *epoll)
     : HttpResponse(location, epoll),
@@ -76,7 +74,8 @@ HttpCgiResponse::MakeResponseBody() {
     cgi_response_body.clear();
 
     if (cgi_process_->IsRemovable()) {
-      write_buffer_.AppendDataToBuffer(kLastChunk);
+      cgi_process_->GetCgiResponse()->AppendLastChunk();
+      write_buffer_.AppendDataToBuffer(cgi_response_body);
       return kComplete;
     } else {
       return kBody;

--- a/srcs/http/http_cgi_response.cpp
+++ b/srcs/http/http_cgi_response.cpp
@@ -72,7 +72,8 @@ HttpCgiResponse::MakeResponseBody() {
   } else {
     utils::ByteVector &cgi_response_body =
         cgi_process_->GetCgiResponse()->GetBody();
-    write_buffer_.AppendDataToBuffer(ConvertToChunkResponse(cgi_response_body));
+    // write_buffer_.AppendDataToBuffer(ConvertToChunkResponse(cgi_response_body));
+    write_buffer_.AppendDataToBuffer(cgi_response_body);
     cgi_response_body.clear();
 
     if (cgi_process_->IsRemovable()) {

--- a/srcs/http/http_cgi_response.hpp
+++ b/srcs/http/http_cgi_response.hpp
@@ -31,8 +31,6 @@ class HttpCgiResponse : public HttpResponse {
 
   // LocalRedirect の結果に基づき新しいリクエストを作成
   HttpRequest CreateLocalRedirectRequest(const HttpRequest &request);
-
-  static std::string ConvertToChunkResponse(utils::ByteVector data);
 };
 
 }  // namespace http

--- a/test/public/cgi-bin/main.c
+++ b/test/public/cgi-bin/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int main(void) {
+	printf("Content-type: text/plain; charset=iso-8859-1\n");
+	printf("\n");
+
+	for (int i = 0; i < 10000000; i++) {
+		printf("%d\n", i);
+	}
+	return 0;
+}

--- a/unit_test/cgi/cgi_response_test.cpp
+++ b/unit_test/cgi/cgi_response_test.cpp
@@ -10,11 +10,13 @@ namespace cgi {
 utils::ByteVector DecodeChunkResponse(utils::ByteVector data) {
   std::string decoded;
 
+  int n;
   while (data.empty() == false) {
     Result<size_t> pos = data.FindString(http::kCrlf);
     std::string line = data.SubstrBeforePos(pos.Ok());
     Result<unsigned long> stoul_res = utils::Stoul(line, utils::kHexadecimal);
     if (stoul_res.Ok() == 0) {
+      EXPECT_EQ(stoul_res.Ok(), 0);
       break;
     }
     data.EraseHead(line.length());
@@ -85,6 +87,7 @@ TEST(CgiResponseParse, ValidDocumentResponseWithoutStatus) {
                                               {"OPTIONAL", "hoge"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
 
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\n"
                               "<body><p>200 OK</p></body>\n"
@@ -155,7 +158,7 @@ TEST(CgiResponseParse, ValidClientRedirectResponseWithDocument) {
       {"EXTENSIONFIELD", "hoge"},
       {"PROTOCOLFIELD", "fuga"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
-
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\n"
                               "<body><p>Let's redirect!!</p></body>\n"
@@ -188,7 +191,7 @@ TEST(CgiResponseParse,
       {"EXTENSIONFIELD", "hoge"},
       {"PROTOCOLFIELD", "fuga"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
-
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\n"
                               "<body><p>Let's redirect!!</p></body>\n"
@@ -215,7 +218,7 @@ TEST(CgiResponseParse, NewLineIsCrlf) {
                                               {"STATUS", "404 Not Found"},
                                               {"OPTIONAL", "hoge"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
-
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\r\n"
                               "<body><p>404 Not Found</p></body>\r\n"
@@ -242,7 +245,7 @@ TEST(CgiResponseParse, DocumentResponsesBodyIncludeLfAndCrlf) {
                                               {"STATUS", "404 Not Found"},
                                               {"OPTIONAL", "hoge"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
-
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\r\n"
                               "<body><p>404 Not Found</p></body>\n"
@@ -287,7 +290,7 @@ TEST(CgiResponseParse, ChoppedBuffer) {
                                               {"STATUS", "404 Not Found"},
                                               {"OPTIONAL", "hoge"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
-
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\n"
                               "<body><p>404 Not Found</p></body>\n"
@@ -331,7 +334,7 @@ TEST(CgiResponseParse, ChoppedBufferThatIsSplitedBeforeHeaderBoundary) {
                                               {"STATUS", "404 Not Found"},
                                               {"OPTIONAL", "hoge"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
-
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\n"
                               "<body><p>404 Not Found</p></body>\n"
@@ -376,7 +379,7 @@ TEST(CgiResponseParse, ChoppedBufferThatIsSplitedInMiddleHeaderBoundary) {
                                               {"STATUS", "404 Not Found"},
                                               {"OPTIONAL", "hoge"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
-
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\n"
                               "<body><p>404 Not Found</p></body>\n"
@@ -422,7 +425,7 @@ TEST(CgiResponseParse, ChoppedBufferThatIsSplitedAftertHeaderBoundary) {
                                               {"STATUS", "404 Not Found"},
                                               {"OPTIONAL", "hoge"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
-
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\n"
                               "<body><p>404 Not Found</p></body>\n"

--- a/unit_test/cgi/cgi_response_test.cpp
+++ b/unit_test/cgi/cgi_response_test.cpp
@@ -15,8 +15,8 @@ utils::ByteVector DecodeChunkResponse(utils::ByteVector data) {
     Result<size_t> pos = data.FindString(http::kCrlf);
     std::string line = data.SubstrBeforePos(pos.Ok());
     Result<unsigned long> stoul_res = utils::Stoul(line, utils::kHexadecimal);
-    if (stoul_res.Ok() == 0) {
-      EXPECT_EQ(stoul_res.Ok(), 0);
+    n = stoul_res.Ok();
+    if (n == 0) {
       break;
     }
     data.EraseHead(line.length());
@@ -25,6 +25,7 @@ utils::ByteVector DecodeChunkResponse(utils::ByteVector data) {
     data.EraseHead(stoul_res.Ok());
     data.EraseHead(http::kCrlf.length());  // crlf
   }
+  EXPECT_EQ(n, 0);
   return decoded;
 }
 

--- a/unit_test/cgi/cgi_response_test.cpp
+++ b/unit_test/cgi/cgi_response_test.cpp
@@ -60,7 +60,7 @@ TEST(CgiResponseParse, DocumentResponseWithStatus) {
                                               {"STATUS", "404 Not Found"},
                                               {"OPTIONAL", "hoge"}};
   EXPECT_EQ_HEADERS(cgi_res.GetHeaders(), expected_headers);
-
+  cgi_res.AppendLastChunk();
   EXPECT_EQ(DecodeChunkResponse(cgi_res.GetBody()),
             utils::ByteVector("<HTML>\n"
                               "<body><p>404 Not Found</p></body>\n"


### PR DESCRIPTION
cgi のハンドラ内でConvertToChunkResponse を 実行