### PR TITLE
CGIスクリプトの出力にwebservが出力する想定のヘッダーが含まれていたら削除する

### DIFF
--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -180,6 +180,21 @@ void CgiResponse::AdjustHeadersBasedOnResponseType() {
       headers_.push_back(HeaderPairType("STATUS", "200 OK"));
     }
   }
+
+  // webserv が出力する想定のヘッダーをCGIスクリプトが出力している場合は削除する
+  std::vector<std::string> webserv_headers;
+  webserv_headers.push_back("CONTENT-LENGTH");
+  webserv_headers.push_back("TRANSFER-ENCODING");
+
+  for (HeaderVecType::iterator it = headers_.begin(); it != headers_.end();) {
+    std::vector<std::string>::iterator webserv_it =
+        std::find(webserv_headers.begin(), webserv_headers.end(), it->first);
+    if (webserv_it != webserv_headers.end()) {
+      it = headers_.erase(it);
+    } else {
+      it++;
+    }
+  }
 }
 
 Result<CgiResponse::HeaderVecType> CgiResponse::GetHeaderVecFromBuffer(

--- a/srcs/cgi/cgi_response.cpp
+++ b/srcs/cgi/cgi_response.cpp
@@ -182,14 +182,14 @@ void CgiResponse::AdjustHeadersBasedOnResponseType() {
   }
 
   // webserv が出力する想定のヘッダーをCGIスクリプトが出力している場合は削除する
-  std::vector<std::string> webserv_headers;
-  webserv_headers.push_back("CONTENT-LENGTH");
-  webserv_headers.push_back("TRANSFER-ENCODING");
+  std::vector<std::string> unacceptable_headers;
+  unacceptable_headers.push_back("CONTENT-LENGTH");
+  unacceptable_headers.push_back("TRANSFER-ENCODING");
 
   for (HeaderVecType::iterator it = headers_.begin(); it != headers_.end();) {
-    std::vector<std::string>::iterator webserv_it =
-        std::find(webserv_headers.begin(), webserv_headers.end(), it->first);
-    if (webserv_it != webserv_headers.end()) {
+    std::vector<std::string>::iterator find_res = std::find(
+        unacceptable_headers.begin(), unacceptable_headers.end(), it->first);
+    if (find_res != unacceptable_headers.end()) {
       it = headers_.erase(it);
     } else {
       it++;

--- a/test/public/cgi-bin/content-length
+++ b/test/public/cgi-bin/content-length
@@ -1,0 +1,10 @@
+#!/usr/bin/python3 -u
+
+res = "abcde あいうえお\n"
+res_bytes = bytes(res, 'utf-8')
+
+print("Content-Type: text/html")
+print(f"Content-Length: {len(res_bytes)}")
+print()
+
+print(res, end="")


### PR DESCRIPTION
`test/public/cgi-bin/content-length` はテスト用のCGIスクリプト