### PR TITLE
autoindexレスポンスにて文字コードUTF-8を指定して返す

### DIFF
--- a/srcs/http/autoindex.cpp
+++ b/srcs/http/autoindex.cpp
@@ -16,7 +16,7 @@ namespace http {
 std::string AutoIndexHead(const std::string &relative_path) {
   std::string head =
       "<html>\n"
-      "<head><title>Index of " +
+      "<head><meta charset=\"UTF-8\"><title>Index of " +
       relative_path +
       "</title></head>\n"
       "<body>\n"


### PR DESCRIPTION
こうしないとブラウザからアクセスしたときに文字化けする