### PR TITLE
CGIはPythonのみ対応にする

### DIFF
--- a/srcs/cgi/cgi_request.cpp
+++ b/srcs/cgi/cgi_request.cpp
@@ -16,6 +16,8 @@
 
 namespace cgi {
 
+const std::string CgiRequest::kPythonPath = "python3";
+
 CgiRequest::CgiRequest() : cgi_pid_(-1), cgi_unisock_(-1) {}
 
 CgiRequest::CgiRequest(const CgiRequest &rhs) {
@@ -199,9 +201,10 @@ void CgiRequest::ExecuteCgi() {
   if (!MoveToCgiExecutionDir(exec_cgi_script_path_)) {
     return;
   }
-  cgi_args_.insert(cgi_args_.begin(), script_name_);
+  cgi_args_.insert(cgi_args_.begin(), kPythonPath);
+  cgi_args_.insert(cgi_args_.begin() + 1, exec_cgi_script_path_);
   char **argv = utils::AllocVectorStringToCharDptr(cgi_args_);
-  execve(exec_cgi_script_path_.c_str(), argv, environ);
+  execvpe(kPythonPath.c_str(), argv, environ);
   utils::DeleteCharDprt(argv);
 }
 

--- a/srcs/cgi/cgi_request.cpp
+++ b/srcs/cgi/cgi_request.cpp
@@ -101,9 +101,10 @@ Result<std::string> CgiRequest::SearchCgiPath(
   for (std::vector<std::string>::const_iterator it = v.begin(); it != v.end();
        it++) {
     exec_cgi_path = utils::JoinPath(exec_cgi_path, *it);
-    Result<bool> is_executable_file_res =
-        utils::IsExecutableFile(exec_cgi_path);
-    if (is_executable_file_res.IsOk() && is_executable_file_res.Ok()) {
+    Result<bool> is_regular_file_res = utils::IsRegularFile(exec_cgi_path);
+    Result<bool> is_readable_file_res = utils::IsReadableFile(exec_cgi_path);
+    if (is_regular_file_res.IsOk() && is_regular_file_res.Ok() &&
+        is_readable_file_res.IsOk() && is_readable_file_res.Ok()) {
       return exec_cgi_path;
     }
   }
@@ -113,9 +114,10 @@ Result<std::string> CgiRequest::SearchCgiPath(
   for (std::vector<std::string>::const_iterator it = index_pages.begin();
        it != index_pages.end(); it++) {
     exec_cgi_path = utils::JoinPath(index_base, *it);
-    Result<bool> is_executable_file_res =
-        utils::IsExecutableFile(exec_cgi_path);
-    if (is_executable_file_res.IsOk() && is_executable_file_res.Ok()) {
+    Result<bool> is_regular_file_res = utils::IsRegularFile(exec_cgi_path);
+    Result<bool> is_readable_file_res = utils::IsReadableFile(exec_cgi_path);
+    if (is_regular_file_res.IsOk() && is_regular_file_res.Ok() &&
+        is_readable_file_res.IsOk() && is_readable_file_res.Ok()) {
       return exec_cgi_path;
     }
   }

--- a/srcs/cgi/cgi_request.cpp
+++ b/srcs/cgi/cgi_request.cpp
@@ -16,7 +16,7 @@
 
 namespace cgi {
 
-const std::string CgiRequest::kPythonPath = "python3";
+const std::string CgiRequest::kPython = "python3";
 
 CgiRequest::CgiRequest() : cgi_pid_(-1), cgi_unisock_(-1) {}
 
@@ -201,10 +201,10 @@ void CgiRequest::ExecuteCgi() {
   if (!MoveToCgiExecutionDir(exec_cgi_script_path_)) {
     return;
   }
-  cgi_args_.insert(cgi_args_.begin(), kPythonPath);
+  cgi_args_.insert(cgi_args_.begin(), kPython);
   cgi_args_.insert(cgi_args_.begin() + 1, exec_cgi_script_path_);
   char **argv = utils::AllocVectorStringToCharDptr(cgi_args_);
-  execvpe(kPythonPath.c_str(), argv, environ);
+  execvpe(kPython.c_str(), argv, environ);
   utils::DeleteCharDprt(argv);
 }
 

--- a/srcs/cgi/cgi_request.hpp
+++ b/srcs/cgi/cgi_request.hpp
@@ -22,7 +22,7 @@ using namespace result;
 
 class CgiRequest {
  private:
-  static const std::string kPythonPath;
+  static const std::string kPython;
 
   pid_t cgi_pid_;
   int cgi_unisock_;

--- a/srcs/cgi/cgi_request.hpp
+++ b/srcs/cgi/cgi_request.hpp
@@ -22,6 +22,8 @@ using namespace result;
 
 class CgiRequest {
  private:
+  static const std::string kPythonPath;
+
   pid_t cgi_pid_;
   int cgi_unisock_;
   std::string script_name_;


### PR DESCRIPTION
正直シェバンに基づいて実行するものでも全然いいと思っているので､チーム内でシェバンを採用することにするのであればこのPRはマージしなくても良い｡

> Your program should call the CGI with the file requested as first argument.

一応シェバンに基づく実行のときも第一引数に script_name 渡しているし､シェバン実行でも良い気がする｡

修正するCGIスクリプトに関しては､レビュー用のCGIスクリプトはPython多めで､なおかつbashで実行予定だったCGIスクリプトも標準出力に出力するだけの簡単なものしか無いので対応は簡単｡

開発時に使ってきた `test/public/cgi-bin` の中のものはある程度の数のファイルに対して対応必要って感じ｡