### PR TITLE
ローカルリダイレクトの修正

### DIFF
--- a/srcs/http/http_request.cpp
+++ b/srcs/http/http_request.cpp
@@ -348,8 +348,7 @@ HttpStatus HttpRequest::InterpretTransferEncoding(
 }
 
 void HttpRequest::ReBindPathAndLocation(const std::string &new_path) {
-  path_ = new_path;
-  parse_status_ = InterpretPath(path_);
+  parse_status_ = InterpretPath(new_path);
   if (parse_status_ != OK) {
     phase_ = kError;
     return;

--- a/test/public/cgi-bin/local-redirect-cat-cgi
+++ b/test/public/cgi-bin/local-redirect-cat-cgi
@@ -1,0 +1,4 @@
+#!/usr/bin/python3 -u
+
+print("Location:/cgi-bin/cat-cgi")
+print()

--- a/test/public/cgi-bin/local-redirect-not-found
+++ b/test/public/cgi-bin/local-redirect-not-found
@@ -1,0 +1,4 @@
+#!/usr/bin/python3 -u
+
+print("Location:/NotExist")
+print()

--- a/test/public/cgi-bin/local-redirect-root
+++ b/test/public/cgi-bin/local-redirect-root
@@ -1,0 +1,4 @@
+#!/usr/bin/python3 -u
+
+print("Location:/")
+print()

--- a/test/public/cgi-bin/local-redirect-sample
+++ b/test/public/cgi-bin/local-redirect-sample
@@ -1,0 +1,4 @@
+#!/usr/bin/python3 -u
+
+print("Location:/sample.html")
+print()

--- a/test/py-test/test_case.py
+++ b/test/py-test/test_case.py
@@ -237,6 +237,34 @@ def cgi_path_info_test():
     run_cmp_test(req_path, expect_port=cmd_args.APACHE_PORT)
 
 
+def cgi_local_redirect_test():
+    req_path = "/cgi-bin/local-redirect-root"
+    run_test(req_path, res.response(200), ck_body=False)
+
+    req_path = "/cgi-bin/local-redirect"
+    run_test(req_path, res.response(200, file_path="public/hoge/hoge.html"))
+
+    req_path = "/cgi-bin/local-redirect-sample"
+    run_test(req_path, res.response(200, file_path="public/sample.html"))
+
+    req_path = "/cgi-bin/local-redirect-loop1"
+    run_test(req_path, res.response(500), ck_body=False)
+
+    req_path = "/cgi-bin/local-redirect-loop1" + "?n=13"
+    run_test(req_path, res.response(500), ck_body=False)
+
+    req_path = "/cgi-bin/local-redirect-loop1" + "?n=3"
+    run_test(req_path, res.response(200), ck_body=False)
+
+    req_path = "/cgi-bin/local-redirect-not-found"
+    run_test(req_path, res.response(404), ck_body=False)
+
+    req_path = "/cgi-bin/local-redirect-cat-cgi"
+    run_test(req_path, res.response(200))
+    run_test(req_path, res.response(200, "hoge"), body="hoge")
+    run_test(req_path, res.response(200, "hoge" * 10000), body="hoge" * 10000)
+
+
 #   path_info デコードで無効な文字が含まれていた場合、エラー
 #     req_path = "/cgi-bin/py-parse-test-cgi/%"
 #     expect_response = send_req(req_path, port=cmd_args.APACHE_PORT)
@@ -274,4 +302,5 @@ def run_all_test() -> bool:
     is_all_test_ok &= exec_test(cgi_has_body_test, must_all_test_ok=False)
     is_all_test_ok &= exec_test(cgi_query_string_test, must_all_test_ok=False)
     is_all_test_ok &= exec_test(cgi_path_info_test, must_all_test_ok=False)
+    is_all_test_ok &= exec_test(cgi_local_redirect_test)
     return is_all_test_ok


### PR DESCRIPTION
InterpretPathの引数で渡した std::string& の参照元を書き換えてしまうので、
InterpretPathの引数を変更した。

ローカルリダイレクトのテストの追加。